### PR TITLE
persists locations between navigation

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -188,6 +188,7 @@ class MainApplication : Application() {
         byDevice?.provideMode = provideMode
 
         connectVc = byDevice?.openConnectViewController()
+        connectVc?.start()
         devicesVc = byDevice?.openDevicesViewController()
         accountVc = byDevice?.openAccountViewController()
     }

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectFragment.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectFragment.kt
@@ -733,33 +733,33 @@ class ConnectAdapter(val connectFragment: ConnectFragment, val connectVc: Connec
     private val connectCountries = mutableMapOf<String, ConnectLocation>()
 
 
-    init {
-        // FIXME view controller to sort the locations before calling callback
-        subs.add(connectVc.addFilteredLocationsListener { exportedLocations ->
-            runBlocking(Dispatchers.Main.immediate) {
-                val locations = mutableListOf<ConnectLocation>()
-                val n = exportedLocations.len()
-                for (i in 0 until n) {
-                    locations.add(exportedLocations.get(i))
-                }
-
-//                Log.i("CONNECT", "UPDATE ON MAIN GOT NEW LOCATIONS $locations")
-
-                connectLocations.clear()
-                connectLocations.addAll(locations)
-
-                connectCountries.clear()
-                connectLocations.forEach { location ->
-                    if (location.locationType == LocationTypeCountry) {
-                        connectCountries[location.countryCode] = location
-                    }
-                }
-
-                // FIXME do a better merge and support stable ids
-                notifyDataSetChanged()
-            }
-        })
-    }
+//    init {
+//        // FIXME view controller to sort the locations before calling callback
+//        subs.add(connectVc.addFilteredLocationsListener { exportedLocations ->
+//            runBlocking(Dispatchers.Main.immediate) {
+//                val locations = mutableListOf<ConnectLocation>()
+//                val n = exportedLocations.len()
+//                for (i in 0 until n) {
+//                    locations.add(exportedLocations.get(i))
+//                }
+//
+////                Log.i("CONNECT", "UPDATE ON MAIN GOT NEW LOCATIONS $locations")
+//
+//                connectLocations.clear()
+//                connectLocations.addAll(locations)
+//
+//                connectCountries.clear()
+//                connectLocations.forEach { location ->
+//                    if (location.locationType == LocationTypeCountry) {
+//                        connectCountries[location.countryCode] = location
+//                    }
+//                }
+//
+//                // FIXME do a better merge and support stable ids
+//                notifyDataSetChanged()
+//            }
+//        })
+//    }
 
 
     // Create new views (invoked by the layout manager)


### PR DESCRIPTION
Previously, every time we hit the connect screen, we were refetching the provider locations. Updated the view controller to persist locations.