### PR TITLE
blue checkmark if location is selected in list

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectFragment.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectFragment.kt
@@ -33,7 +33,7 @@ import com.bringyour.client.Client.LocationTypeCountry
 import com.bringyour.client.Client.LocationTypeRegion
 import com.bringyour.client.ConnectLocation
 import com.bringyour.client.ConnectViewController
-import com.bringyour.client.LocationListener
+// import com.bringyour.client.LocationListener
 import com.bringyour.client.Sub
 import com.bringyour.network.MainActivity
 import com.bringyour.network.MainApplication
@@ -181,95 +181,95 @@ class ConnectFragment : Fragment() {
                 animateJob = null
             } else {
                 val view: View
-                if (location.isGroup) {
-                    view = LayoutInflater.from(connectTop.context)
-                        .inflate(R.layout.connect_top_group, connectTop, true)
-                    val viewHolder = ConnectTopGroupViewHolder(view)
-                    // todo there is no sub currently
-                    viewHolder.locationChanged(location)
-                } else if (location.isDevice) {
-                    view = LayoutInflater.from(connectTop.context)
-                        .inflate(R.layout.connect_top_device, connectTop, true)
-                    val viewHolder = ConnectTopDeviceViewHolder(view)
-                    // todo there is no sub currently
-                    viewHolder.locationChanged(location)
-                } else {
-                    when (location.locationType) {
-                        LocationTypeCity -> {
-                            view = LayoutInflater.from(connectTop.context)
-                                .inflate(R.layout.connect_top_city, connectTop, true)
-                            val viewHolder = ConnectTopCityViewHolder(this, view)
-                            // todo there is no sub currently
-                            viewHolder.locationChanged(location)
-                        }
-
-                        LocationTypeRegion -> {
-                            view = LayoutInflater.from(connectTop.context)
-                                .inflate(R.layout.connect_top_region, connectTop, true)
-                            val viewHolder = ConnectTopRegionViewHolder(this, view)
-                            // todo there is no sub currently
-                            viewHolder.locationChanged(location)
-                        }
-
-                        else -> {
-                            view = LayoutInflater.from(connectTop.context)
-                                .inflate(R.layout.connect_top_country, connectTop, true)
-                            val viewHolder = ConnectTopCountryViewHolder(this, view)
-                            // todo there is no sub currently
-                            viewHolder.locationChanged(location)
-                        }
-                    }
-                }
+//                if (location.isGroup) {
+//                    view = LayoutInflater.from(connectTop.context)
+//                        .inflate(R.layout.connect_top_group, connectTop, true)
+//                    val viewHolder = ConnectTopGroupViewHolder(view)
+//                    // todo there is no sub currently
+//                    viewHolder.locationChanged(location)
+//                } else if (location.isDevice) {
+//                    view = LayoutInflater.from(connectTop.context)
+//                        .inflate(R.layout.connect_top_device, connectTop, true)
+//                    val viewHolder = ConnectTopDeviceViewHolder(view)
+//                    // todo there is no sub currently
+//                    viewHolder.locationChanged(location)
+//                } else {
+//                    when (location.locationType) {
+//                        LocationTypeCity -> {
+//                            view = LayoutInflater.from(connectTop.context)
+//                                .inflate(R.layout.connect_top_city, connectTop, true)
+//                            val viewHolder = ConnectTopCityViewHolder(this, view)
+//                            // todo there is no sub currently
+//                            viewHolder.locationChanged(location)
+//                        }
+//
+//                        LocationTypeRegion -> {
+//                            view = LayoutInflater.from(connectTop.context)
+//                                .inflate(R.layout.connect_top_region, connectTop, true)
+//                            val viewHolder = ConnectTopRegionViewHolder(this, view)
+//                            // todo there is no sub currently
+//                            viewHolder.locationChanged(location)
+//                        }
+//
+//                        else -> {
+//                            view = LayoutInflater.from(connectTop.context)
+//                                .inflate(R.layout.connect_top_country, connectTop, true)
+//                            val viewHolder = ConnectTopCountryViewHolder(this, view)
+//                            // todo there is no sub currently
+//                            viewHolder.locationChanged(location)
+//                        }
+//                    }
+//                }
 
                 // add common listeners
 
 
-                val disconnectButton = view.findViewById<Button>(R.id.connect_disconnect)
-                disconnectButton?.setOnClickListener {
-                    connectVc.disconnect()
-                }
+//                val disconnectButton = view.findViewById<Button>(R.id.connect_disconnect)
+//                disconnectButton?.setOnClickListener {
+//                    connectVc.disconnect()
+//                }
 
-                val shuffleButton = view.findViewById<ImageButton>(R.id.connect_shuffle)
-                shuffleButton?.setOnClickListener {
-                    connectVc.shuffle()
-                }
-
-                val broadenButton = view.findViewById<ImageButton>(R.id.connect_broaden)
-                broadenButton?.setOnClickListener {
-                    connectVc.broaden()
-                }
-
-
-                val issueButton = view.findViewById<Button>(R.id.connect_issue)
-                issueButton?.setOnClickListener {
-                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://support.bringyour.com")))
-                }
-
-                view.findViewById<TextView>(R.id.connect_header)?.let { connectHeader ->
-                    updateWindowStats(connectHeader)
-                }
-
-                if (animateJob?.isActive != true) {
-                    connectTop.findViewById<View>(R.id.connect_top_image)?.let { connectTopImage ->
-                        connectTopImage.visibility = View.VISIBLE
-                    }
-                }
+//                val shuffleButton = view.findViewById<ImageButton>(R.id.connect_shuffle)
+//                shuffleButton?.setOnClickListener {
+//                    connectVc.shuffle()
+//                }
+//
+//                val broadenButton = view.findViewById<ImageButton>(R.id.connect_broaden)
+//                broadenButton?.setOnClickListener {
+//                    connectVc.broaden()
+//                }
+//
+//
+//                val issueButton = view.findViewById<Button>(R.id.connect_issue)
+//                issueButton?.setOnClickListener {
+//                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://support.bringyour.com")))
+//                }
+//
+//                view.findViewById<TextView>(R.id.connect_header)?.let { connectHeader ->
+//                    updateWindowStats(connectHeader)
+//                }
+//
+//                if (animateJob?.isActive != true) {
+//                    connectTop.findViewById<View>(R.id.connect_top_image)?.let { connectTopImage ->
+//                        connectTopImage.visibility = View.VISIBLE
+//                    }
+//                }
             }
         }
 
-        subs.add(connectVc.addConnectionListener { location ->
-
-            runBlocking(Dispatchers.Main.immediate) {
-
-                setActiveLocation(location)
-
-                if (app.isVpnRequestStart()) {
-                    // user might need to grant permissions
-                    (activity as MainActivity).requestPermissionsThenStartVpnServiceWithRestart()
-                }
-            }
-
-        })
+//        subs.add(connectVc.addConnectionListener { location ->
+//
+//            runBlocking(Dispatchers.Main.immediate) {
+//
+//                setActiveLocation(location)
+//
+//                if (app.isVpnRequestStart()) {
+//                    // user might need to grant permissions
+//                    (activity as MainActivity).requestPermissionsThenStartVpnServiceWithRestart()
+//                }
+//            }
+//
+//        })
 
 
 
@@ -1168,143 +1168,143 @@ class ConnectDeviceViewHolder(val connectFragment: ConnectFragment, connectVc: C
 }
 
 
-class ConnectTopGroupViewHolder(val view: View) : LocationListener {
-    val groupLabelView: TextView
-    val providerSummaryView: TextView
-
-    init {
-        groupLabelView = view.findViewById<TextView>(R.id.connect_location_group_label)
-        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
-    }
-
-    override fun locationChanged(location: ConnectLocation) {
-        groupLabelView.text = location.name
-        val providerSummary: String
-        if (location.providerCount == 1) {
-            providerSummary = "${location.providerCount} provider"
-        } else {
-            providerSummary = "${location.providerCount} providers"
-        }
-        providerSummaryView.text = providerSummary
-    }
-}
-
-
-class ConnectTopDeviceViewHolder(val view: View) : LocationListener {
-    val deviceLabelView: TextView
-
-    init {
-        deviceLabelView = view.findViewById<TextView>(R.id.connect_location_device_label)
-    }
-
-    override fun locationChanged(location: ConnectLocation) {
-        deviceLabelView.text = location.name
-    }
-}
+//class ConnectTopGroupViewHolder(val view: View) : LocationListener {
+//    val groupLabelView: TextView
+//    val providerSummaryView: TextView
+//
+//    init {
+//        groupLabelView = view.findViewById<TextView>(R.id.connect_location_group_label)
+//        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
+//    }
+//
+//    override fun locationChanged(location: ConnectLocation) {
+//        groupLabelView.text = location.name
+//        val providerSummary: String
+//        if (location.providerCount == 1) {
+//            providerSummary = "${location.providerCount} provider"
+//        } else {
+//            providerSummary = "${location.providerCount} providers"
+//        }
+//        providerSummaryView.text = providerSummary
+//    }
+//}
 
 
-class ConnectTopCityViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
-    val countryImageView: ImageView
-    val cityLabelView: TextView
-    val regionLabelView: TextView
-    val countryLabelView: TextView
-    val providerSummaryView: TextView
+//class ConnectTopDeviceViewHolder(val view: View) : LocationListener {
+//    val deviceLabelView: TextView
+//
+//    init {
+//        deviceLabelView = view.findViewById<TextView>(R.id.connect_location_device_label)
+//    }
+//
+//    override fun locationChanged(location: ConnectLocation) {
+//        deviceLabelView.text = location.name
+//    }
+//}
 
-    init {
-        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
-        cityLabelView = view.findViewById<TextView>(R.id.connect_location_city_label)
-        regionLabelView = view.findViewById<TextView>(R.id.connect_location_region_label)
-        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
-        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
-    }
 
-    override fun locationChanged(location: ConnectLocation) {
-        val context = view.context
-        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
-        Glide.with(connectFragment)
-            .load(resId)
-            .override(512)
-            .priority(Priority.LOW)
-            .into(countryImageView)
-
-        cityLabelView.text = location.name
-        regionLabelView.text = location.region
-        countryLabelView.text = location.country
-
-        val providerSummary: String
-        if (location.providerCount == 1) {
-            providerSummary = "${location.providerCount} provider"
-        } else {
-            providerSummary = "${location.providerCount} providers"
-        }
-        providerSummaryView.text = providerSummary
-    }
-}
-
-class ConnectTopRegionViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
-    val countryImageView: ImageView
-    val regionLabelView: TextView
-    val countryLabelView: TextView
-    val providerSummaryView: TextView
-
-    init {
-        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
-        regionLabelView = view.findViewById<TextView>(R.id.connect_location_region_label)
-        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
-        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
-    }
-
-    override fun locationChanged(location: ConnectLocation) {
-        val context = view.context
-        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
-        Glide.with(connectFragment)
-            .load(resId)
-            .override(512)
-            .priority(Priority.LOW)
-            .into(countryImageView)
-
-        regionLabelView.text = location.name
-        countryLabelView.text = location.country
-
-        val providerSummary: String
-        if (location.providerCount == 1) {
-            providerSummary = "${location.providerCount} provider"
-        } else {
-            providerSummary = "${location.providerCount} providers"
-        }
-        providerSummaryView.text = providerSummary
-    }
-}
-
-class ConnectTopCountryViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
-    val countryImageView: ImageView
-    val countryLabelView: TextView
-    val providerSummaryView: TextView
-
-    init {
-        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
-        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
-        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
-    }
-
-    override fun locationChanged(location: ConnectLocation) {
-        val context = view.context
-        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
-        Glide.with(connectFragment)
-            .load(resId)
-            .override(512)
-            .priority(Priority.LOW)
-            .into(countryImageView)
-
-        countryLabelView.text = location.name
-
-        val providerSummary: String
-        if (location.providerCount == 1) {
-            providerSummary = "${location.providerCount} provider"
-        } else {
-            providerSummary = "${location.providerCount} providers"
-        }
-        providerSummaryView.text = providerSummary
-    }
-}
+//class ConnectTopCityViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
+//    val countryImageView: ImageView
+//    val cityLabelView: TextView
+//    val regionLabelView: TextView
+//    val countryLabelView: TextView
+//    val providerSummaryView: TextView
+//
+//    init {
+//        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
+//        cityLabelView = view.findViewById<TextView>(R.id.connect_location_city_label)
+//        regionLabelView = view.findViewById<TextView>(R.id.connect_location_region_label)
+//        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
+//        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
+//    }
+//
+//    override fun locationChanged(location: ConnectLocation) {
+//        val context = view.context
+//        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
+//        Glide.with(connectFragment)
+//            .load(resId)
+//            .override(512)
+//            .priority(Priority.LOW)
+//            .into(countryImageView)
+//
+//        cityLabelView.text = location.name
+//        regionLabelView.text = location.region
+//        countryLabelView.text = location.country
+//
+//        val providerSummary: String
+//        if (location.providerCount == 1) {
+//            providerSummary = "${location.providerCount} provider"
+//        } else {
+//            providerSummary = "${location.providerCount} providers"
+//        }
+//        providerSummaryView.text = providerSummary
+//    }
+//}
+//
+//class ConnectTopRegionViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
+//    val countryImageView: ImageView
+//    val regionLabelView: TextView
+//    val countryLabelView: TextView
+//    val providerSummaryView: TextView
+//
+//    init {
+//        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
+//        regionLabelView = view.findViewById<TextView>(R.id.connect_location_region_label)
+//        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
+//        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
+//    }
+//
+//    override fun locationChanged(location: ConnectLocation) {
+//        val context = view.context
+//        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
+//        Glide.with(connectFragment)
+//            .load(resId)
+//            .override(512)
+//            .priority(Priority.LOW)
+//            .into(countryImageView)
+//
+//        regionLabelView.text = location.name
+//        countryLabelView.text = location.country
+//
+//        val providerSummary: String
+//        if (location.providerCount == 1) {
+//            providerSummary = "${location.providerCount} provider"
+//        } else {
+//            providerSummary = "${location.providerCount} providers"
+//        }
+//        providerSummaryView.text = providerSummary
+//    }
+//}
+//
+//class ConnectTopCountryViewHolder(val connectFragment: ConnectFragment, val view: View) : LocationListener {
+//    val countryImageView: ImageView
+//    val countryLabelView: TextView
+//    val providerSummaryView: TextView
+//
+//    init {
+//        countryImageView = view.findViewById<ImageView>(R.id.connect_top_image)
+//        countryLabelView = view.findViewById<TextView>(R.id.connect_location_country_label)
+//        providerSummaryView = view.findViewById<TextView>(R.id.connect_provider_summary)
+//    }
+//
+//    override fun locationChanged(location: ConnectLocation) {
+//        val context = view.context
+//        val resId = context.resources.getIdentifier("country_${location.countryCode}_512", "drawable", context.packageName)
+//        Glide.with(connectFragment)
+//            .load(resId)
+//            .override(512)
+//            .priority(Priority.LOW)
+//            .into(countryImageView)
+//
+//        countryLabelView.text = location.name
+//
+//        val providerSummary: String
+//        if (location.providerCount == 1) {
+//            providerSummary = "${location.providerCount} provider"
+//        } else {
+//            providerSummary = "${location.providerCount} providers"
+//        }
+//        providerSummaryView.text = providerSummary
+//    }
+//}
 

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectScreen.kt
@@ -81,7 +81,7 @@ fun ConnectScreen(
         }
     }
 
-    val getSelectedLocation = {
+    val initSelectedLocation = {
         selectedLocation = connectVc?.selectedLocation
     }
 
@@ -95,20 +95,11 @@ fun ConnectScreen(
         }
     }
 
-    val addConnectionListener = {
+    val addSelectedLocationListener = {
         if (connectVc != null) {
-            subs.add(connectVc.addConnectionListener { location ->
+            subs.add(connectVc.addSelectedLocationListener { location ->
                 runBlocking(Dispatchers.Main.immediate) {
-
-                    // selectedLocation = location
-                    getSelectedLocation()
-                    getConnectionStatus()
-
-
-                    if (application.isVpnRequestStart()) {
-                        // user might need to grant permissions
-                        activity?.requestPermissionsThenStartVpnServiceWithRestart()
-                    }
+                    selectedLocation = location
                 }
             })
         }
@@ -121,6 +112,10 @@ fun ConnectScreen(
                     val statusFromStr = ConnectStatus.fromString(status)
                     if (statusFromStr != null) {
                         connectStatus = statusFromStr
+
+                        if (connectStatus == ConnectStatus.CONNECTED && application.isVpnRequestStart()) {
+                            activity?.requestPermissionsThenStartVpnServiceWithRestart()
+                        }
                     }
                 }
             })
@@ -129,7 +124,7 @@ fun ConnectScreen(
 
     LaunchedEffect(Unit) {
         populateNetworkName()
-        getSelectedLocation()
+        initSelectedLocation()
         getConnectionStatus()
     }
 
@@ -138,8 +133,8 @@ fun ConnectScreen(
         Log.i("ConnectScreen", "DisposableEffect called")
 
         // init subs
-        addConnectionListener()
         addConnectionStatusListener()
+        addSelectedLocationListener()
 
         // when closing
         onDispose {

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/LocationsList.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/LocationsList.kt
@@ -18,7 +18,8 @@ import com.bringyour.client.ConnectViewController
 fun LocationsList(
     connectCountries: Map<String, ConnectLocation>,
     connectVc: ConnectViewController?,
-    onLocationSelect: () -> Unit
+    onLocationSelect: () -> Unit,
+    selectedLocation: ConnectLocation?
 ) {
 
     val countryList = connectCountries.entries.toList()
@@ -43,7 +44,8 @@ fun LocationsList(
                 onClick = {
                     connectVc?.connect(country.value)
                     onLocationSelect()
-                }
+                },
+                isSelected = selectedLocation?.connectLocationId == country.value.connectLocationId
             )
         }
     }

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ProviderRow.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ProviderRow.kt
@@ -1,19 +1,27 @@
 package com.bringyour.network.ui.connect
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bringyour.network.ui.components.CircleImage
+import com.bringyour.network.ui.theme.BlueMedium
+import com.bringyour.network.ui.theme.TextMuted
 import com.bringyour.network.ui.theme.URNetworkTheme
 import java.text.NumberFormat
 import java.util.Locale
@@ -23,7 +31,8 @@ fun ProviderRow(
     location: String,
     providerCount: Int,
     imageResourceId: Int? = null,
-    onClick: (Int) -> Unit
+    onClick: (Int) -> Unit,
+    isSelected: Boolean = false
 ) {
 
     val formatter = NumberFormat.getNumberInstance(Locale.US)
@@ -33,20 +42,32 @@ fun ProviderRow(
             .fillMaxWidth()
             .clickable {
                 onClick(1)
-            }
+            },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        CircleImage(
-            size = 40.dp,
-            imageResourceId
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Column {
-            Row {
-                Text(location)
+        Row() {
+            CircleImage(
+                size = 40.dp,
+                imageResourceId
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Row {
+                    Text(location)
+                }
+                Row {
+                    Text("${formatter.format(providerCount)} Providers", style = MaterialTheme.typography.bodyMedium)
+                }
             }
-            Row {
-                Text("${formatter.format(providerCount)} Providers", style = MaterialTheme.typography.bodyMedium)
-            }
+        }
+
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = "Keyboard Arrow Right",
+                tint = BlueMedium
+            )
         }
     }
     
@@ -61,6 +82,19 @@ fun ProviderRowPreview() {
             location = "Switzerland",
             providerCount = 1520,
             onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun ProviderRowSelectedPreview() {
+    URNetworkTheme {
+        ProviderRow(
+            location = "Switzerland",
+            providerCount = 1520,
+            onClick = {},
+            isSelected = true
         )
     }
 }

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ProvidersBottomSheetScaffold.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ProvidersBottomSheetScaffold.kt
@@ -236,7 +236,8 @@ fun ProvidersBottomSheetScaffold(
                         connectVc = connectVc,
                         onLocationSelect = {
                             scope.launch { scaffoldState.bottomSheetState.partialExpand() }
-                        }
+                        },
+                        selectedLocation
                     )
                 }
             }


### PR DESCRIPTION
Some refactoring has been done. Now, instead of listening to activeLocation, we listen to two separate events:
- selected location updated
- connection status updated
This way, we can persist a location, even if the connection status is disconnected.

Also, adds the blue checkmark in the locations list if selected