### PR TITLE
fixes to the vpn routing

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
 <!--    <uses-sdk android:minSdkVersion="24"/>-->
 
+
 <!--    android:logo="@drawable/logo_by"-->
     <!-- see https://developer.android.com/privacy-and-security/security-config -->
     <application
@@ -60,6 +61,12 @@
             android:exported="true"
             android:label="@string/app_name"
             android:foregroundServiceType="dataSync">
+
+            <intent-filter>
+                <action android:name="android.net.VpnService"/>
+            </intent-filter>
+            <meta-data android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
+                android:value="true"/>
 
         </service>
 

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -247,6 +247,7 @@ class MainApplication : Application() {
         val vpnIntent = Intent(this, MainService::class.java)
         vpnIntent.putExtra("stop", false)
         vpnIntent.putExtra("start", true)
+        vpnIntent.putExtra("route-local", isRouteLocal())
         vpnIntent.putExtra("foreground", true)
         try {
             sendVpnServiceIntent(vpnIntent)
@@ -379,12 +380,22 @@ class MainApplication : Application() {
     fun setProvideMode(provideMode: Long) {
         // store the setting in local storage
         asyncLocalState?.localState()?.provideMode = provideMode
-        byDevice?.setProvideMode(provideMode)
+        byDevice?.provideMode = provideMode
 
     }
 
     fun getProvideMode(): Long {
         return asyncLocalState?.localState()?.provideMode!!
+    }
+
+    fun setRouteLocal(routeLocal: Boolean) {
+        // store the setting in local storage
+        asyncLocalState?.localState()?.routeLocal = routeLocal
+        byDevice?.routeLocal = routeLocal
+    }
+
+    fun isRouteLocal(): Boolean {
+        return asyncLocalState?.localState()?.routeLocal!!
     }
 
     fun isVpnRequestStart(): Boolean {

--- a/app/app/src/main/java/com/bringyour/network/MainService.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainService.kt
@@ -52,6 +52,9 @@ class MainService : VpnService() {
 
         val app = application as MainApplication
 
+//        Log.i(TAG,"START INTENT = $intent")
+
+
 
         intent?.getBooleanExtra("stop", false)?.let { stop ->
             if (stop) {
@@ -66,6 +69,10 @@ class MainService : VpnService() {
 
         intent?.getBooleanExtra("start", true)?.let { start ->
             if (start) {
+                // see https://developer.android.com/develop/connectivity/vpn#detect_always-on
+                intent.getBooleanExtra("route-local", false).let { routeLocal ->
+                    app.byDevice?.setRouteLocal(routeLocal)
+                }
 
                 app.router?.let { router ->
                     // TODO
@@ -77,6 +84,9 @@ class MainService : VpnService() {
                     builder.setMtu(1440)
                     builder.setBlocking(true)
                     builder.addDisallowedApplication(packageName)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        builder.setMetered(false)
+                    }
 
                     if (router.clientIpv4 != null) {
                         builder.allowFamily(AF_INET)

--- a/app/app/src/main/java/com/bringyour/network/Router.kt
+++ b/app/app/src/main/java/com/bringyour/network/Router.kt
@@ -20,8 +20,12 @@ class Router(val byDevice: BringYourDevice) {
         val WRITE_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(5L)
     }
 
-    val clientIpv4: String? = "10.10.11.11"
+    val clientIpv4: String? = "169.254.2.1"
     val clientIpv4PrefixLength = 32
+    // see:
+    // https://security.googleblog.com/2022/07/dns-over-http3-in-android.html#fn2
+    // only Google DNS and CloudFlare DNS will auto-enable DoT/DoH on Android
+    // *important* removing the Google public server will disable DoT/DoH
     val dnsIpv4s = listOf("1.1.1.1", "8.8.8.8", "9.9.9.9")
 
     val clientIpv6: String? = null

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.5.2' apply false
-    id 'com.android.library' version '8.5.2' apply false
+    id 'com.android.application' version '8.6.0' apply false
+    id 'com.android.library' version '8.6.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.23' apply false
 }

--- a/app/gradle/wrapper/gradle-wrapper.properties
+++ b/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 01 12:49:50 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- set the network to unmetered Metered networks generally cause things to not work well. Our intended use case is unmetered.
- support android always-on mode (set from settings) In this mode, the VPN can come on and block all traffic until properly started with the broadcast receiver or user action.

Depends on https://github.com/bringyour/bringyour/pull/73