### PR TITLE
Connect locations list bugfix 2

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -37,6 +38,7 @@ import com.bringyour.network.ui.components.ButtonStyle
 import com.bringyour.network.ui.components.LoginMode
 import com.bringyour.network.ui.components.URButton
 import com.bringyour.network.ui.theme.Black
+import com.bringyour.network.ui.theme.Red
 import com.bringyour.network.ui.theme.URNetworkTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -66,7 +68,8 @@ fun ConnectScreen(
             grid = connectViewModel.grid,
             loginMode = accountViewModel.loginMode,
             animatedSuccessPoints = connectViewModel.shuffledSuccessPoints,
-            shuffleSuccessPoints = connectViewModel.shuffleSuccessPoints
+            shuffleSuccessPoints = connectViewModel.shuffleSuccessPoints,
+            getStateColor = connectViewModel.getStateColor
         )
     }
 }
@@ -83,7 +86,8 @@ fun ConnectMainContent(
     disconnect: () -> Unit?,
     loginMode: LoginMode,
     animatedSuccessPoints: List<AnimatedSuccessPoint>,
-    shuffleSuccessPoints: () -> Unit
+    shuffleSuccessPoints: () -> Unit,
+    getStateColor: (ProviderPointState?) -> Color
 ) {
 
     var currentStatus by remember { mutableStateOf<ConnectStatus?>(null) }
@@ -170,7 +174,8 @@ fun ConnectMainContent(
                     providerGridPoints = providerGridPoints,
                     grid = grid,
                     animatedSuccessPoints = animatedSuccessPoints,
-                    shuffleSuccessPoints = shuffleSuccessPoints
+                    shuffleSuccessPoints = shuffleSuccessPoints,
+                    getStateColor = getStateColor
                 )
             }
 
@@ -240,6 +245,8 @@ fun ConnectMainContent(
 @Preview
 @Composable
 private fun ConnectMainContentPreview() {
+    val mockGetStateColor: (ProviderPointState?) -> Color = { Red }
+
     URNetworkTheme {
         ConnectMainContent(
             connectStatus = ConnectStatus.DISCONNECTED,
@@ -252,7 +259,8 @@ private fun ConnectMainContentPreview() {
             windowCurrentSize = 16,
             loginMode = LoginMode.Authenticated,
             animatedSuccessPoints = listOf(),
-            shuffleSuccessPoints = {}
+            shuffleSuccessPoints = {},
+            getStateColor = mockGetStateColor
         )
     }
 }

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectViewModel.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectViewModel.kt
@@ -24,6 +24,7 @@ import com.bringyour.network.ui.theme.BlueLight
 import com.bringyour.network.ui.theme.Green
 import com.bringyour.network.ui.theme.Pink
 import com.bringyour.network.ui.theme.Red
+import com.bringyour.network.ui.theme.TextFaint
 import com.bringyour.network.ui.theme.Yellow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.cancel
@@ -150,17 +151,6 @@ class ConnectViewModel @Inject constructor(
         }
     }
 
-//    private val addWindowEventSizeListener = {
-//
-//        addListener { vc ->
-//            vc.addWindowSizeListener {
-//                viewModelScope.launch {
-//                    windowCurrentSize = vc.grid?.windowCurrentSize ?: 0
-//                }
-//            }
-//        }
-//    }
-
     private val addGridListener = {
         addListener { vc ->
             vc.addGridListener {
@@ -188,6 +178,17 @@ class ConnectViewModel @Inject constructor(
         } ?: run {
             windowCurrentSize = 0
             providerGridPoints = mapOf()
+        }
+    }
+
+    val getStateColor: (ProviderPointState?) -> Color = { state ->
+        when (state) {
+            ProviderPointState.IN_EVALUATION -> Yellow
+            ProviderPointState.EVALUATION_FAILED -> Red
+            ProviderPointState.NOT_ADDED -> TextFaint
+            ProviderPointState.ADDED -> Green
+            ProviderPointState.REMOVED -> Red
+            else -> Color.Transparent
         }
     }
 


### PR DESCRIPTION
Connect fixes related to https://github.com/bringyour/bringyour/pull/106

Did some small clean up. These can be removed, but generally thought it was easier:
- most animations can just use the current state. simplified the state machine
- I don’t see why we need a “disconnect” button separate from a “cancel” button. just disconnect seems fine?
- on disconnect we don’t need to animate points to zero radius. they will just be removed