### PR TITLE
Locations error tap to refresh

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/connect/FetchLocationsError.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/FetchLocationsError.kt
@@ -1,0 +1,79 @@
+package com.bringyour.network.ui.connect
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bringyour.network.R
+import com.bringyour.network.ui.theme.MainTintedBackgroundBase
+import com.bringyour.network.ui.theme.TextMuted
+import com.bringyour.network.ui.theme.URNetworkTheme
+import com.bringyour.network.ui.theme.Yellow
+
+@Composable
+fun FetchLocationsError(
+    onRefresh: () -> Unit,
+) {
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                onRefresh()
+            }
+            .background(MainTintedBackgroundBase, shape = RoundedCornerShape(12.dp))
+            .padding(24.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Warning,
+            contentDescription = stringResource(id = R.string.check_internet),
+            tint = Yellow
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            Row {
+                Text(
+                    stringResource(id = R.string.check_internet),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+
+            Row {
+                Text(
+                    stringResource(id = R.string.tap_to_refetch),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = TextMuted
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun FetchLocationsErrorPreview() {
+    URNetworkTheme {
+        FetchLocationsError(
+            onRefresh = {}
+        )
+    }
+}

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/LocationsList.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/LocationsList.kt
@@ -1,91 +1,43 @@
 package com.bringyour.network.ui.connect
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import com.bringyour.client.ConnectLocation
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.bringyour.network.R
 import com.bringyour.network.ui.theme.Red400
-import com.bringyour.network.ui.theme.TextMuted
-import com.bringyour.network.ui.theme.Yellow
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LocationsList(
+    searchQuery: String,
     connectCountries: List<ConnectLocation>,
     promotedLocations: List<ConnectLocation>,
     devices: List<ConnectLocation>,
     onLocationSelect: (ConnectLocation?) -> Unit,
     selectedLocation: ConnectLocation?,
     getLocationColor: (String) -> Color,
-    isRefreshing: Boolean,
     onRefresh: () -> Unit,
 ) {
 
-    val state = rememberPullToRefreshState()
-
-    if (promotedLocations.isEmpty() && connectCountries.isEmpty() && devices.isEmpty()) {
-        PullToRefreshBox(
-            state = state,
-            isRefreshing = isRefreshing,
-            onRefresh = onRefresh,
-        ) {
-
-            LazyColumn {
-                item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Warning,
-                            contentDescription = stringResource(id = R.string.check_internet),
-                            tint = Yellow
-                        )
-
-                        Spacer(modifier = Modifier.width(16.dp))
-
-                        Column {
-                            Row {
-                                Text(
-                                    stringResource(id = R.string.check_internet),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                )
-                            }
-
-                            Row {
-                                Text(
-                                    stringResource(id = R.string.no_providers_found),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = TextMuted
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    if (promotedLocations.isEmpty() && connectCountries.isEmpty() && devices.isEmpty() && searchQuery.isEmpty()) {
+        FetchLocationsError(
+            onRefresh = onRefresh
+        )
+    } else if (promotedLocations.isEmpty() && connectCountries.isEmpty() && devices.isEmpty() && searchQuery.isNotEmpty()) {
+        // searching but no results found!
+        NoLocationsFound()
     } else {
+        // success
         LazyColumn {
             if (promotedLocations.isNotEmpty()) {
                 item {

--- a/app/app/src/main/java/com/bringyour/network/ui/connect/NoLocationsFound.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/NoLocationsFound.kt
@@ -1,0 +1,58 @@
+package com.bringyour.network.ui.connect
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bringyour.network.R
+import com.bringyour.network.ui.theme.MainTintedBackgroundBase
+import com.bringyour.network.ui.theme.TextMuted
+import com.bringyour.network.ui.theme.URNetworkTheme
+
+@Composable
+fun NoLocationsFound() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MainTintedBackgroundBase, shape = RoundedCornerShape(12.dp))
+            .padding(24.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = stringResource(id = R.string.no_providers_found),
+            tint = TextMuted
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Row {
+            Text(
+                stringResource(id = R.string.no_providers_found),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NoLocationsFoundPreview() {
+    URNetworkTheme {
+        NoLocationsFound()
+    }
+}

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="search_placeholder">Search for all locations</string>
     <string name="check_internet">Check your internet connection</string>
     <string name="no_providers_found">We could not find any providers.</string>
+    <string name="tap_to_refetch">Tap to try and fetch location.</string>
 
     <!-- Account Screen -->
     <string name="account">Account</string>


### PR DESCRIPTION
Removes the pull to refresh in the dialog. If there is an error state, displays a message that says tap to refresh.