### PR TITLE
Fix top crash in Play crash logs

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/wallet/WalletViewModel.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/wallet/WalletViewModel.kt
@@ -20,6 +20,7 @@ import com.bringyour.client.ValidateAddressCallback
 import com.bringyour.client.WalletViewController
 import com.bringyour.network.ByDeviceManager
 import com.bringyour.network.CircleWalletManager
+import com.bringyour.network.TAG
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -205,10 +206,13 @@ class WalletViewModel @Inject constructor(
     }
 
     private val fetchCircleWalletInfo = {
-        byDevice?.api?.subscriptionBalance { result, _ ->
-
-            viewModelScope.launch {
-                setCircleWalletBalance(Client.nanoCentsToUsd(result.walletInfo.balanceUsdcNanoCents))
+        byDevice?.api?.subscriptionBalance { result, error ->
+            if (error != null) {
+                Log.i(TAG, "[wallet]fetch error = $error")
+            } else {
+                viewModelScope.launch {
+                    setCircleWalletBalance(Client.nanoCentsToUsd(result.walletInfo.balanceUsdcNanoCents))
+                }
             }
         }
     }


### PR DESCRIPTION
https://play.google.com/console/u/0/developers/6526591383079622643/app/4973787292033394323/vitals/crashes?days=28&versionCode=12518&isUserPerceived=true

```
Exception java.lang.NullPointerException:
  at com.bringyour.network.ui.wallet.WalletViewModel$fetchCircleWalletInfo$1$1$1.invokeSuspend (WalletViewModel.kt:211)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:108)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:9063)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:588)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```