### PR TITLE
boot receiver: change the way the service is started on boot

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -464,7 +464,7 @@ class MainApplication : Application() {
         val routeLocal = byDevice.routeLocal
 
         if (provideEnabled || connectEnabled || !routeLocal) {
-            startVpnService()
+            startVpnService(true)
             // if provide paused, keep the vpn on but do not keep the locks
             if (provideEnabled && !providePaused) {
                 if (wakeLock == null) {
@@ -511,13 +511,12 @@ class MainApplication : Application() {
     }
 
 
-    fun startVpnService() {
+    fun startVpnService(foreground: Boolean) {
         val byDevice = byDevice ?: return
 
 
         val offline = byDevice.offline
         val vpnInterfaceWhileOffline = byDevice.vpnInterfaceWhileOffline
-        val foreground = true
 
         val vpnIntent = Intent(this, MainService::class.java)
         vpnIntent.putExtra("source", "app")

--- a/app/app/src/main/java/com/bringyour/network/StartReceiver.kt
+++ b/app/app/src/main/java/com/bringyour/network/StartReceiver.kt
@@ -12,7 +12,10 @@ class StartReceiver : BroadcastReceiver() {
             Intent.ACTION_BOOT_COMPLETED, Intent.ACTION_MY_PACKAGE_REPLACED, Intent.ACTION_MY_PACKAGE_UNSUSPENDED -> {
                 val app = context.applicationContext as MainApplication
                 if (app.vpnRequestStart) {
-                    app.startVpnService()
+                    // note starting in Android 15, boot completed receivers cannot start foreground services
+                    // see https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed
+                    // TODO do we need to use a foreground service generally
+                    app.startVpnService(false)
                 }
             }
         }


### PR DESCRIPTION
To be compatible with new foreground service rules.

https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed

