### PR TITLE
fix issues with service start

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -307,11 +307,11 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.15.0'
 
     // jetpack compose
-    def composeBom = platform('androidx.compose:compose-bom:2024.11.00')
+    def composeBom = platform('androidx.compose:compose-bom:2024.12.01')
     implementation composeBom
     androidTestImplementation composeBom
 
-    implementation("androidx.navigation:navigation-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.5")
     implementation "androidx.activity:activity-compose:1.9.3"
 
     // Material Design 3
@@ -320,12 +320,12 @@ dependencies {
     implementation 'androidx.compose.material3:material3-window-size-class-android:1.3.1'
 
     // UI Tests
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.7.5'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.7.5'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.7.6'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.7.6'
 
     // Android Studio Preview support
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.7.5'
-    debugImplementation 'androidx.compose.ui:ui-tooling:1.7.5'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.7.6'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.7.6'
 }
 
 // circle wallet
@@ -336,7 +336,7 @@ dependencies {
 // google play
 dependencies {
     // FIXME only bundle if using google play flavor
-    implementation 'com.google.android.gms:play-services-auth:21.2.0'
+    implementation 'com.google.android.gms:play-services-auth:21.3.0'
     implementation "com.android.installreferrer:installreferrer:2.2"
 
     // play store review


### PR DESCRIPTION
Change the way the service is started and stopped to avoid mixing `startService` with `startForegroundService`. Additionally, simplify the way `startForeground` is called inside the service.

Also update dependencies for latest bug fixes.
