### PR TITLE
service: fix foreground usage (again)

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainActivity.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainActivity.kt
@@ -107,6 +107,8 @@ class MainActivity: AppCompatActivity() {
         // immutable shadow
         val app = application as MainApplication
 
+        app.allowForeground = true
+
         sagaActivitySender = ActivityResultSender(this)
 
         reviewManager = ReviewManagerFactory.create(this)

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -56,6 +56,7 @@ class MainApplication : Application() {
     }
 
     var networkSpaceSub: Sub? = null
+    var allowForeground: Boolean = false
 
 //    var byDevice: BringYourDevice? = null
     var deviceProvideSub: Sub? = null
@@ -512,7 +513,10 @@ class MainApplication : Application() {
     }
 
     fun startVpnService() {
-        startVpnServiceWithForeground(true)
+        // note starting in Android 15, boot completed receivers cannot start foreground services
+        // the app will not allow foreground until the activity is explicitly opened
+        // see https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed
+        startVpnServiceWithForeground(allowForeground)
     }
 
     fun startVpnServiceWithForeground(foreground: Boolean) {

--- a/app/app/src/main/java/com/bringyour/network/StartReceiver.kt
+++ b/app/app/src/main/java/com/bringyour/network/StartReceiver.kt
@@ -12,10 +12,7 @@ class StartReceiver : BroadcastReceiver() {
             Intent.ACTION_BOOT_COMPLETED, Intent.ACTION_MY_PACKAGE_REPLACED, Intent.ACTION_MY_PACKAGE_UNSUSPENDED -> {
                 val app = context.applicationContext as MainApplication
                 if (app.vpnRequestStart) {
-                    // note starting in Android 15, boot completed receivers cannot start foreground services
-                    // see https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed
-                    // TODO do we need to use a foreground service generally
-                    app.startVpnServiceWithForeground(false)
+                    app.startVpnService()
                 }
             }
         }


### PR DESCRIPTION
Allow foreground service only when the app is explicitly opened. Otherwise do not use foreground service.