### PR TITLE
remove deprecated edge-to-edge

### DIFF
--- a/app/app/src/google/java/com/bringyour/network/LoginActivity.kt
+++ b/app/app/src/google/java/com/bringyour/network/LoginActivity.kt
@@ -50,14 +50,6 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
 
-        val lightTransparentStyle = SystemBarStyle.dark(
-            scrim = TRANSPARENT
-        )
-        enableEdgeToEdge(
-            statusBarStyle = lightTransparentStyle,
-            navigationBarStyle = lightTransparentStyle
-        )
-
         super.onCreate(savedInstanceState)
 
         app = application as MainApplication

--- a/app/app/src/google/java/com/bringyour/network/MainActivity.kt
+++ b/app/app/src/google/java/com/bringyour/network/MainActivity.kt
@@ -103,13 +103,6 @@ class MainActivity: AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val lightTransparentStyle = SystemBarStyle.dark(
-            scrim = TRANSPARENT
-        )
-        enableEdgeToEdge(
-            statusBarStyle = lightTransparentStyle,
-            navigationBarStyle = lightTransparentStyle
-        )
 
         super.onCreate(savedInstanceState)
 

--- a/app/app/src/main/java/com/bringyour/network/ui/account/AccountScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/account/AccountScreen.kt
@@ -94,6 +94,7 @@ fun AccountScreen(
                 .fillMaxSize()
                 .background(Black)
                 .padding(innerPadding)
+                .padding(16.dp),
         ) {
 
             AccountScreenContent(

--- a/app/app/src/main/java/com/bringyour/network/ui/feedback/FeedbackScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/feedback/FeedbackScreen.kt
@@ -340,6 +340,8 @@ private fun FeedbackForm(
 
     Column {
 
+        Spacer(modifier = Modifier.height(16.dp))
+
         URButton(
             onClick = {
                 sendFeedback()

--- a/app/app/src/ungoogle/java/com/bringyour/network/MainActivity.kt
+++ b/app/app/src/ungoogle/java/com/bringyour/network/MainActivity.kt
@@ -90,13 +90,6 @@ class MainActivity: AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val lightTransparentStyle = SystemBarStyle.dark(
-            scrim = TRANSPARENT
-        )
-        enableEdgeToEdge(
-            statusBarStyle = lightTransparentStyle,
-            navigationBarStyle = lightTransparentStyle
-        )
 
         super.onCreate(savedInstanceState)
 


### PR DESCRIPTION
Per the docs (https://developer.android.com/develop/ui/views/layout/edge-to-edge?authuser=1#enable-edge-to-edge-display), edge-to-edge is enabled by default, so we can remove manually calling it.