### PR TITLE
Service fixes

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -108,6 +108,7 @@ class MainApplication : Application() {
 
 
     var service: WeakReference<MainService>? = null
+    var serviceActive: Boolean = false
 
 
 
@@ -588,6 +589,8 @@ class MainApplication : Application() {
                     vpnRequestStart = true
                     vpnRequestStartListener?.let { it() }
                 } else {
+                    serviceActive = true
+
                     if (foreground) {
                         // use a foreground service to allow notifications
                         if (Build.VERSION_CODES.TIRAMISU <= Build.VERSION.SDK_INT) {
@@ -641,6 +644,7 @@ class MainApplication : Application() {
         //
         // using a weak reference to the service is strangely the cleanest approach
 
+        serviceActive = false
         service?.get()?.stop()
 //        tunnelRequestStatus = TunnelRequestStatus.Stopped
 

--- a/app/app/src/main/java/com/bringyour/network/MainService.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainService.kt
@@ -63,7 +63,7 @@ class MainService : VpnService() {
         val stop = intent?.getBooleanExtra("stop", false) ?: false
         val start = intent?.getBooleanExtra("start", true) ?: false
 
-        if (stop) {
+        if (stop || !app.serviceActive) {
             stop()
         } else if (start) {
             app.service?.get().let { currentService ->


### PR DESCRIPTION
Fixes to address a race condition with how we start/stop the VPN service. The fundamental issue appears to be start followed by stop *before the service is started*. In the previous implementation we would leak the service in that case, by never delivering a stop.

https://github.com/urnetwork/android/issues/264
