### PR TITLE
Always on fix

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -24,10 +24,6 @@
     <!-- this is included in a Google dependency and we *do not* want it. -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
-    <!-- prevent these from ever being added by a dependency -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove"/>
-
     <!-- for tv support -->
     <uses-feature android:name="android.hardware.touchscreen"
         android:required="false" />
@@ -36,6 +32,14 @@
     <uses-feature
         android:name="android.software.leanback"
         android:required="false" />
+
+    <!-- prevent these from ever being added by a dependency -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.location.gps"
+        android:required="false" tools:node="remove"/>
+
+
 
 
     <!--    android:logo="@drawable/logo_by"-->

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -650,12 +650,12 @@ class MainApplication : Application() {
 //        tunnelRequestStatus = TunnelRequestStatus.Stopped
 
 
-        val vpnIntent = Intent(this, MainService::class.java)
-        vpnIntent.putExtra("source", "app")
-        vpnIntent.putExtra("stop", true)
-        vpnIntent.putExtra("start", false)
-        vpnIntent.putExtra("foreground", false)
-        stopService(vpnIntent)
+//        val vpnIntent = Intent(this, MainService::class.java)
+//        vpnIntent.putExtra("source", "app")
+//        vpnIntent.putExtra("stop", true)
+//        vpnIntent.putExtra("start", false)
+//        vpnIntent.putExtra("foreground", false)
+//        stopService(vpnIntent)
 
 //        try {
 //            // note this cannot be called in OnCreate, or it will prevent the routes from being set up correctly

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -646,14 +646,17 @@ class MainApplication : Application() {
 
         serviceActive = false
         service?.get()?.stop()
+
 //        tunnelRequestStatus = TunnelRequestStatus.Stopped
 
 
-//        val vpnIntent = Intent(this, MainService::class.java)
-//        vpnIntent.putExtra("source", "app")
-//        vpnIntent.putExtra("stop", true)
-//        vpnIntent.putExtra("start", false)
-//        vpnIntent.putExtra("foreground", false)
+        val vpnIntent = Intent(this, MainService::class.java)
+        vpnIntent.putExtra("source", "app")
+        vpnIntent.putExtra("stop", true)
+        vpnIntent.putExtra("start", false)
+        vpnIntent.putExtra("foreground", false)
+        stopService(vpnIntent)
+
 //        try {
 //            // note this cannot be called in OnCreate, or it will prevent the routes from being set up correctly
 //            startService(vpnIntent)

--- a/app/app/src/main/java/com/bringyour/network/MainService.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainService.kt
@@ -85,6 +85,8 @@ class MainService : VpnService() {
                 stopForegroundNotification()
             }
 
+            // FIXME just let the user toggle route local which is also called "kill switch"
+            /*
             // see https://developer.android.com/develop/connectivity/vpn#detect_always-on
             var alwaysOn = source != "app"
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -97,6 +99,7 @@ class MainService : VpnService() {
                 // turn off local routing
                 app.deviceManager.routeLocal = false
             }
+            */
 
             val builder = Builder()
             builder.setSession("URnetwork")


### PR DESCRIPTION
The app was conflating always on with route local (aka kill switch). In fact it is not always on that affects route local, but the undetectable "block connections without vpn". It's much simpler to just let the user manually toggle route local, to get what they want.

Depends on https://github.com/urnetwork/sdk/pull/53