### PR TITLE
service: better handle the race condition between multiple start/stop calls

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -412,7 +412,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.16.0'
 
     // jetpack compose
-    def composeBom = platform('androidx.compose:compose-bom:2025.05.00')
+    def composeBom = platform('androidx.compose:compose-bom:2025.05.01')
     implementation composeBom
     androidTestImplementation composeBom
 
@@ -426,12 +426,12 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:1.7.8"
 
     // UI Tests
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.8.1'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.8.1'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.8.2'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest:1.8.2'
 
     // Android Studio Preview support
-    implementation 'androidx.compose.ui:ui-tooling-preview:1.8.1'
-    debugImplementation 'androidx.compose.ui:ui-tooling:1.8.1'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.8.2'
+    debugImplementation 'androidx.compose.ui:ui-tooling:1.8.2'
 
     // reflect
     implementation 'org.jetbrains.kotlin:kotlin-reflect:2.1.20'

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -108,8 +108,16 @@ class MainApplication : Application() {
 
 
     var service: WeakReference<MainService>? = null
-    var serviceActive: Boolean = false
-
+    private var _serviceActive: Boolean = false
+    val serviceActiveMonitor = Object()
+    var serviceActive: Boolean
+        get() = synchronized(serviceActiveMonitor) {
+            return _serviceActive
+        }
+        set(it) = synchronized(serviceActiveMonitor) {
+            _serviceActive = it
+            serviceActiveMonitor.notifyAll()
+        }
 
 
     override fun onCreate() {
@@ -647,6 +655,9 @@ class MainApplication : Application() {
         // using a weak reference to the service is strangely the cleanest approach
 
         serviceActive = false
+        synchronized(serviceActiveMonitor) {
+            serviceActiveMonitor.notifyAll()
+        }
         service?.get()?.stop()
 
 //        tunnelRequestStatus = TunnelRequestStatus.Stopped
@@ -671,6 +682,7 @@ class MainApplication : Application() {
 
 
     }
+
 }
 
 //enum class TunnelRequestStatus {


### PR DESCRIPTION
If multiple service instances are started concurrently there would be an issue with the previous implementation. This change adds extra protections to make sure the service is stopped correctly.
