### PR TITLE
send numeric otp if userauth login verification required

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/login/LoginPassword.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/login/LoginPassword.kt
@@ -96,6 +96,7 @@ fun LoginPassword(
         val args = AuthLoginWithPasswordArgs()
         args.userAuth = user.text
         args.password = password.text
+        args.verifyOtpNumeric = true
 
         app?.api?.authLoginWithPassword(args) { result, err ->
             runBlocking(Dispatchers.Main.immediate) {


### PR DESCRIPTION
bugfix: when a user tries to login but verification is still required, need to send a numeric OTP for verification