### PR TITLE
truncate connect client id in ui

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectActions.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/connect/ConnectActions.kt
@@ -370,7 +370,7 @@ fun OpenProviderListButton(
     val text = if (selectedLocation == null || selectedLocation.connectLocationId.bestAvailable) {
         stringResource(id = R.string.best_available_provider)
     } else {
-        selectedLocation.name
+        selectedLocation.name.truncateClientId()
     }
 
     val iconTint = if (selectedLocation == null || selectedLocation.connectLocationId.bestAvailable) {
@@ -447,6 +447,10 @@ fun OpenProviderListButton(
             )
         }
     }
+}
+
+fun String.truncateClientId(): String {
+    return if (length > 12) "${take(4)}...${takeLast(4)}" else this
 }
 
 @Composable


### PR DESCRIPTION
Fixes #458

Truncates the connect client ID to "abcd...1234" format to prevent the "Change" button from being squished when connected to a client with a long ID.