### PR TITLE
fix(android): don't capture apps through a tunnel with no live exit

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainService.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainService.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.ParcelFileDescriptor
 import android.system.OsConstants.AF_INET
+import android.system.OsConstants.AF_INET6
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.bringyour.network.utils.sdkStringListToList
@@ -30,6 +31,13 @@ import kotlin.concurrent.thread
     companion object {
         const val NOTIFICATION_ID = 101
         const val NOTIFICATION_CHANNEL_ID = "URnetwork"
+        /**
+         * IPv4 used to establish the tunnel when the SDK has not handed back a
+         * tunnel address, so a tunnel is always built (fail-closed). TEST-NET-1
+         * (192.0.2.0/24) is reserved documentation space. With capture routes it
+         * is a blocking blackhole; with no routes (escape) it routes nothing.
+         */
+        const val ESCAPE_FALLBACK_ADDRESS = "192.0.2.1"
 
         fun defaultExcludedPackageNames(): List<String> {
             // TODO grass, spectrum, session, discord
@@ -85,6 +93,10 @@ import kotlin.concurrent.thread
 
     private var deviceOfflineSub: Sub? = null
     private var windowStatusChangeSub: Sub? = null
+    /** Rebuilds the TUN when the kill switch (routeLocal) toggles. */
+    private var routeLocalSub: Sub? = null
+    /** Rebuilds the TUN when a connect request starts or stops. */
+    private var connectChangeSub: Sub? = null
     private var blockActionOverridesSub: Sub? = null
     private var dnsResolverSettingsSub: Sub? = null
     private var connected: Boolean = false
@@ -250,6 +262,19 @@ import kotlin.concurrent.thread
                 if (boundDevice === currentDevice) reconcilePfd()
             }
         }
+        // killSwitch (routeLocal) and connectRequested (connectEnabled) are
+        // material inputs to vpnPacketFlowMode: toggling either must rebuild
+        // the TUN so the routing mode changes, not just the service start.
+        routeLocalSub = currentDevice.addRouteLocalChangeListener {
+            Handler(mainLooper).post {
+                if (boundDevice === currentDevice) reconcilePfd()
+            }
+        }
+        connectChangeSub = currentDevice.addConnectChangeListener {
+            Handler(mainLooper).post {
+                if (boundDevice === currentDevice) reconcilePfd()
+            }
+        }
         reconcilePfd()
     }
 
@@ -267,13 +292,19 @@ import kotlin.concurrent.thread
         val app = application as MainApplication
         val (includedAppIds, excludedAppIds) = tunnelAppSplit()
         val clientIpv4 = vpnTunnelIpv4Address(app.device?.tunnelLocalAddress())
+        // The tunnel binds this address (falling back to ESCAPE_FALLBACK_ADDRESS)
+        // in updatePfd, so the DNS self-collision filter must use the same bound
+        // address: a DNS entry equal to the bound address is locally terminated.
+        val boundIpv4 = clientIpv4 ?: ESCAPE_FALLBACK_ADDRESS
         val deviceDnsIpv4s = tunnelDnsServers()
         return VpnPacketFlowConfiguration(
             offline = offline,
             connected = connected,
+            killSwitch = app.device?.routeLocal == false,
+            connectRequested = app.device?.connectEnabled == true,
             includedAppIds = includedAppIds.toSet(),
             excludedAppIds = excludedAppIds.toSet(),
-            dnsIpv4s = vpnDnsServersForClient(clientIpv4, deviceDnsIpv4s, dnsIpv4s),
+            dnsIpv4s = vpnDnsServersForClient(boundIpv4, deviceDnsIpv4s, dnsIpv4s),
             clientIpv4 = clientIpv4,
         )
     }
@@ -317,59 +348,101 @@ import kotlin.concurrent.thread
         val tunnelExcludedAppIds = configuration.excludedAppIds
         val tunnelDnsIpv4s = configuration.dnsIpv4s
 
-        if (configuration.offline) {
-//            Log.i(TAG, "[io]OFFLINE")
-            // when offline, only allow traffic from a fake package name
-            // in this way, the vpn service remains active but no apps detect it as an interface
-            builder.addAllowedApplication("${packageName}.offline")
-        } else if (tunnelIncludedAppIds.isNotEmpty()) {
-            // per-app inclusions take precedence: allowlist mode, only the
-            // included apps use the tunnel. tunnelAppSplit sanitizes the VPN
-            // owner before this mode decision, so a stale self-only rule
-            // cannot create an empty Android UID set.
-            for (includedPackageName in tunnelIncludedAppIds) {
-                try {
-                    builder.addAllowedApplication(includedPackageName)
-                } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
+        // Routing mode is a pure decision so the fail-closed/escape path is
+        // unit-testable without an Android runtime. Named args avoid a silent
+        // positional swap of the two booleans. ESCAPE (offline, or up purely
+        // for provide with no live exit) keeps the tunnel established but adds
+        // no routes and no DNS, so Android points nothing at it: every app
+        // (including the tunnel owner) keeps its native network and DNS, and
+        // there is no dependence on an installed allow-listed package.
+        val mode = vpnPacketFlowMode(
+            offline = configuration.offline,
+            connected = configuration.connected,
+            killSwitch = configuration.killSwitch,
+            connectRequested = configuration.connectRequested,
+            includedAppIds = tunnelIncludedAppIds,
+        )
+        when (mode) {
+            VpnPacketFlowMode.ESCAPE -> {
+                // no app rules; the escape build below adds routes/DNS only for
+                // non-escape modes, so nothing is captured
+            }
+            VpnPacketFlowMode.PER_APP_ALLOWLIST -> {
+                    // per-app inclusions take precedence: allowlist mode, only
+                    // the included apps use the tunnel. tunnelAppSplit
+                    // sanitizes the VPN owner before this mode decision, so a
+                    // stale self-only rule cannot create an empty Android UID
+                    // set.
+                    for (includedPackageName in tunnelIncludedAppIds) {
+                        try {
+                            builder.addAllowedApplication(includedPackageName)
+                        } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
+                        }
+                    }
+                }
+                VpnPacketFlowMode.DENYLIST -> {
+                    // denylist mode: everything not the tunnel owner uses the
+                    // tunnel, except the default excluded apps and per-app
+                    // exclusions
+                    builder.addDisallowedApplication(packageName)
+                    for (excludedPackageName in defaultExcludedPackageNames() + tunnelExcludedAppIds) {
+                        try {
+                            builder.addDisallowedApplication(excludedPackageName)
+                        } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
+                        }
+                    }
                 }
             }
-        } else {
-            // denylist mode: everything uses the tunnel except this app,
-            // the default excluded apps, and the per-app exclusions
-            builder.addDisallowedApplication(packageName)
-            for (excludedPackageName in defaultExcludedPackageNames() + tunnelExcludedAppIds) {
-                try {
-                    builder.addDisallowedApplication(excludedPackageName)
-                } catch (_: android.content.pm.PackageManager.NameNotFoundException) {
-                }
-            }
-        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             builder.setMetered(false)
         }
 
         when (configuration.ipv6Policy) {
             VpnIpv6Policy.BLOCK_UNSUPPORTED -> {
-                // Deliberately omit IPv6 address/route/DNS and allowFamily.
-                // Android blocks the unconfigured family while this IPv4-only
-                // VPN is active, matching the remote provider capability.
+                // For CAPTURE modes (allowlist/denylist): omit IPv6 entirely.
+                // Remote providers are IPv4-only, so the tunnel cannot forward
+                // IPv6; blocking the unconfigured family is correct there.
+                // The ESCAPE path below separately calls allowFamily(AF_INET6)
+                // so the phone's other apps keep their own IPv6 connectivity.
             }
         }
 
         val clientIpv4 = configuration.clientIpv4
-        if (clientIpv4 != null) {
+        val isEscape = mode == VpnPacketFlowMode.ESCAPE
+        // Always establish a tunnel, even when the SDK has not handed back a
+        // tunnel address. Without an address builder.establish() throws and
+        // the catch retains the previous interface, or with no prior interface
+        // leaves no TUN at all. For a kill-switch or connected state that
+        // fails OPEN (traffic to the ISP in the clear). Use a fixed
+        // documentation address (same class the always-on guard uses) as a
+        // fail-closed fallback: with capture routes it is a blocking blackhole;
+        // with no routes (escape) it routes nothing.
+        val tunnelAddress = clientIpv4 ?: ESCAPE_FALLBACK_ADDRESS
+        val ipv6Report = if (isEscape) "on" else "off"
+        if (isEscape) {
+            // Escaping: allow BOTH families. With no app rules every app is in
+            // scope, so without allowFamily(AF_INET6) the unconfigured IPv6
+            // family would be BLOCKED for every app (the exact bug this fix
+            // removes, on the v6 half). Address only, no routes, no DNS:
+            // Android routes nothing into it and every app keeps its native
+            // network and DNS.
             builder.allowFamily(AF_INET)
-            builder.addAddress(
-                clientIpv4,
-                clientIpv4PrefixLength
-            )
-            // DNS from the SDK device (see `tunnelDnsServers`). It must be a
-            // distinct address routed through the TUN: Android locally
-            // terminates packets addressed to clientIpv4 before PacketFlow can
-            // hand them to UpgradeMux.
-            for (dnsIpv4 in tunnelDnsIpv4s) {
-                builder.addDnsServer(dnsIpv4)
-            }
+            builder.allowFamily(AF_INET6)
+        } else {
+            builder.allowFamily(AF_INET)
+        }
+        builder.addAddress(
+            tunnelAddress,
+            clientIpv4PrefixLength
+        )
+            if (!isEscape) {
+                // DNS from the SDK device (see `tunnelDnsServers`). It must
+                // be a distinct address routed through the TUN: Android
+                // locally terminates packets addressed to clientIpv4 before
+                // PacketFlow can hand them to UpgradeMux.
+                for (dnsIpv4 in tunnelDnsIpv4s) {
+                    builder.addDnsServer(dnsIpv4)
+                }
             if (Build.VERSION_CODES.TIRAMISU <= Build.VERSION.SDK_INT) {
                 builder.addRoute("0.0.0.0", 0)
                 builder.excludeRoute(IpPrefix(InetAddress.getByName("10.0.0.0"), 8))
@@ -421,7 +494,7 @@ import kotlin.concurrent.thread
                 builder.addRoute("8.0.0.0", 7)
                 builder.addRoute("11.0.0.0", 8)
             }
-        }
+            }
         app.device?.let { device ->
             val pfd = try {
                 builder.establish()
@@ -453,7 +526,7 @@ import kotlin.concurrent.thread
                     "[service]tunnel applied offline=${configuration.offline} connected=${configuration.connected} " +
                         "included=${configuration.includedAppIds.size} excluded=${configuration.excludedAppIds.size} " +
                         "dns=${configuration.dnsIpv4s} address=${configuration.clientIpv4} " +
-                        "tunnelIpv6=off underlyingIpv6=blocked",
+                        "tunnelIpv6=${ipv6Report}",
                 )
                 if (app.service?.get() == this@MainService) {
                     device.tunnelStarted = true
@@ -544,6 +617,10 @@ import kotlin.concurrent.thread
         blockActionOverridesSub = null
         dnsResolverSettingsSub?.close()
         dnsResolverSettingsSub = null
+        routeLocalSub?.close()
+        routeLocalSub = null
+        connectChangeSub?.close()
+        connectChangeSub = null
         boundDevice = null
         if (closePacketFlow) {
             packetFlow?.close()

--- a/app/app/src/main/java/com/bringyour/network/VpnPacketFlowConfiguration.kt
+++ b/app/app/src/main/java/com/bringyour/network/VpnPacketFlowConfiguration.kt
@@ -10,6 +10,13 @@ package com.bringyour.network
 internal data class VpnPacketFlowConfiguration(
     val offline: Boolean,
     val connected: Boolean,
+    // killSwitch = !device.routeLocal ("Allow local traffic when disconnected").
+    // When on, the tunnel must capture/block even without an exit: that is the
+    // feature, not a bug. connectRequested = device.connectEnabled: when the
+    // user wants their own traffic tunneled, never escape on a transient
+    // provider dip (intent does not flap; liveness does).
+    val killSwitch: Boolean,
+    val connectRequested: Boolean,
     val includedAppIds: Set<String>,
     val excludedAppIds: Set<String>,
     val dnsIpv4s: List<String>,
@@ -25,6 +32,42 @@ internal data class VpnPacketFlowConfiguration(
  */
 internal enum class VpnIpv6Policy {
     BLOCK_UNSUPPORTED,
+}
+
+/**
+ * Which routing policy to apply when building the VPN packet flow.
+ *
+ * ESCAPE keeps the tunnel technically up (so provide stays armed) but lets no
+ * real app see it: used when the device is offline OR when there is no live
+ * provider exit yet (connected == false). Failing closed on !connected stops
+ * other apps being captured into a tunnel that has no working egress, which
+ * blackholes their DNS and connectivity.
+ */
+internal enum class VpnPacketFlowMode {
+    ESCAPE,
+    PER_APP_ALLOWLIST,
+    DENYLIST,
+}
+
+/**
+ * Decides the routing mode from the tunnel config. Pure, so it is
+ * unit-testable without an Android runtime.
+ */
+internal fun vpnPacketFlowMode(
+    offline: Boolean,
+    connected: Boolean,
+    killSwitch: Boolean,
+    connectRequested: Boolean,
+    includedAppIds: Set<String>,
+): VpnPacketFlowMode = when {
+    offline -> VpnPacketFlowMode.ESCAPE
+    // Escape only when the tunnel is up PURELY for provide (no kill switch,
+    // no connect intent, no live exit). In every other not-connected case the
+    // user asked for capture (kill switch) or for their traffic to be held
+    // (connect): those must not escape, or they leak to the ISP in the clear.
+    !connected && !killSwitch && !connectRequested -> VpnPacketFlowMode.ESCAPE
+    includedAppIds.isNotEmpty() -> VpnPacketFlowMode.PER_APP_ALLOWLIST
+    else -> VpnPacketFlowMode.DENYLIST
 }
 
 internal fun vpnPacketFlowNeedsRebuild(

--- a/app/app/src/test/java/com/bringyour/network/VpnPacketFlowConfigurationTest.kt
+++ b/app/app/src/test/java/com/bringyour/network/VpnPacketFlowConfigurationTest.kt
@@ -2,6 +2,7 @@ package com.bringyour.network
 
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -9,6 +10,8 @@ class VpnPacketFlowConfigurationTest {
     private fun configuration(
         offline: Boolean = false,
         connected: Boolean = true,
+        killSwitch: Boolean = false,
+        connectRequested: Boolean = false,
         includedAppIds: Set<String> = emptySet(),
         excludedAppIds: Set<String> = emptySet(),
         dnsIpv4s: List<String> = listOf("65.49.70.65"),
@@ -17,6 +20,8 @@ class VpnPacketFlowConfigurationTest {
         return VpnPacketFlowConfiguration(
             offline = offline,
             connected = connected,
+            killSwitch = killSwitch,
+            connectRequested = connectRequested,
             includedAppIds = includedAppIds,
             excludedAppIds = excludedAppIds,
             dnsIpv4s = dnsIpv4s,
@@ -124,6 +129,523 @@ class VpnPacketFlowConfigurationTest {
         assertEquals(
             VpnIpv6Policy.BLOCK_UNSUPPORTED,
             configuration().ipv6Policy,
+        )
+    }
+
+    @Test
+    fun notConnectedProvideOnlyRoutesToEscape() {
+        // The reported bug: provide mode Always keeps the tunnel up whenever on
+        // a network. With no live exit, no kill switch, and no connect request,
+        // the tunnel is up purely to provide: escape (add no routes/DNS) so the
+        // device's own apps keep native connectivity.
+        assertEquals(
+            VpnPacketFlowMode.ESCAPE,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = false, connectRequested = false, includedAppIds = emptySet()),
+        )
+    }
+
+    @Test
+    fun offlineAlwaysRoutesToEscapeEvenWhenConnected() {
+        assertEquals(
+            VpnPacketFlowMode.ESCAPE,
+            vpnPacketFlowMode(offline = true, connected = true, killSwitch = false, connectRequested = false, includedAppIds = setOf("com.android.chrome")),
+        )
+    }
+
+    @Test
+    fun killSwitchKeepsCapturingEvenWhenNotConnected() {
+        // Security regression guard: the kill switch ("Allow local traffic when
+        // disconnected" off) is implemented BY capturing everything with no
+        // exit. ESCAPE must never release the user's traffic to the ISP while
+        // the kill switch is on, even when not connected.
+        assertEquals(
+            VpnPacketFlowMode.DENYLIST,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = true, connectRequested = false, includedAppIds = emptySet()),
+        )
+    }
+
+    @Test
+    fun killSwitchKeepsAllowingExplicitIncludesWhenNotConnected() {
+        assertEquals(
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = true, connectRequested = false, includedAppIds = setOf("com.android.chrome")),
+        )
+    }
+
+    @Test
+    fun connectRequestedKeepsTrafficCapturedDuringProviderDip() {
+        // Liveness-flap guard: `connected` is a liveness signal that can
+        // momentarily empty during attach or provider rotation. When the user
+        // requested connect, intent does not flap, so do not escape: keep the
+        // user's traffic captured (do not leak it to the ISP).
+        assertEquals(
+            VpnPacketFlowMode.DENYLIST,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = false, connectRequested = true, includedAppIds = emptySet()),
+        )
+    }
+
+    @Test
+    fun connectRequestedWithIncludesStaysAllowlistDuringProviderDip() {
+        assertEquals(
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = false, connectRequested = true, includedAppIds = setOf("com.android.chrome")),
+        )
+    }
+
+    @Test
+    fun connectedWithNoIncludesRoutesToDenylist() {
+        assertEquals(
+            VpnPacketFlowMode.DENYLIST,
+            vpnPacketFlowMode(offline = false, connected = true, killSwitch = false, connectRequested = false, includedAppIds = emptySet()),
+        )
+    }
+
+    @Test
+    fun connectedWithIncludesRoutesToPerAppAllowlist() {
+        assertEquals(
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            vpnPacketFlowMode(offline = false, connected = true, killSwitch = false, connectRequested = false, includedAppIds = setOf("com.android.chrome")),
+        )
+    }
+
+    @Test
+    fun notConnectedProvideOnlyIgnoresPerAppIncludesAndStillEscapes() {
+        // Fails closed even when the user configured per-app includes: with no
+        // live exit and no capture reason, nothing should be captured.
+        assertEquals(
+            VpnPacketFlowMode.ESCAPE,
+            vpnPacketFlowMode(offline = false, connected = false, killSwitch = false, connectRequested = false, includedAppIds = setOf("com.android.chrome")),
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // Corrected-semantics guards (appended). Each of these fails under at
+    // least one of the two superseded rule sets:
+    //   7.22:        escape <=> offline
+    //   first pass:  escape <=> offline || !connected   (defeated the kill switch)
+    // ---------------------------------------------------------------------
+
+    private val someIncludes = setOf("com.android.chrome")
+
+    private fun mode(
+        offline: Boolean = false,
+        connected: Boolean = true,
+        killSwitch: Boolean = false,
+        connectRequested: Boolean = false,
+        includedAppIds: Set<String> = emptySet(),
+    ): VpnPacketFlowMode = vpnPacketFlowMode(
+        offline = offline,
+        connected = connected,
+        killSwitch = killSwitch,
+        connectRequested = connectRequested,
+        includedAppIds = includedAppIds,
+    )
+
+    private fun describe(
+        offline: Boolean,
+        connected: Boolean,
+        killSwitch: Boolean,
+        connectRequested: Boolean,
+        includedAppIds: Set<String>,
+    ): String =
+        "offline=$offline connected=$connected killSwitch=$killSwitch " +
+            "connectRequested=$connectRequested includes=${includedAppIds.size}"
+
+    // --- offline dominates every other input -----------------------------
+
+    @Test
+    fun offlineWithKillSwitchStillEscapes() {
+        // Offline means there is no underlying network at all, so there is
+        // nothing to leak to: keep the interface but route nothing into it.
+        assertEquals(
+            "offline must escape even with the kill switch on",
+            VpnPacketFlowMode.ESCAPE,
+            mode(offline = true, connected = false, killSwitch = true),
+        )
+    }
+
+    @Test
+    fun offlineWithConnectRequestedStillEscapes() {
+        assertEquals(
+            "offline must escape even when the user requested connect",
+            VpnPacketFlowMode.ESCAPE,
+            mode(offline = true, connected = false, connectRequested = true),
+        )
+    }
+
+    @Test
+    fun offlineWithEveryCaptureReasonSetStillEscapes() {
+        assertEquals(
+            "offline outranks connected + killSwitch + connectRequested + includes",
+            VpnPacketFlowMode.ESCAPE,
+            mode(
+                offline = true,
+                connected = true,
+                killSwitch = true,
+                connectRequested = true,
+                includedAppIds = someIncludes,
+            ),
+        )
+    }
+
+    @Test
+    fun offlineEscapesForEveryCombinationOfTheOtherInputs() {
+        for (connected in listOf(false, true)) {
+            for (killSwitch in listOf(false, true)) {
+                for (connectRequested in listOf(false, true)) {
+                    for (includes in listOf(emptySet(), someIncludes)) {
+                        assertEquals(
+                            "offline must always escape: " +
+                                describe(true, connected, killSwitch, connectRequested, includes),
+                            VpnPacketFlowMode.ESCAPE,
+                            mode(
+                                offline = true,
+                                connected = connected,
+                                killSwitch = killSwitch,
+                                connectRequested = connectRequested,
+                                includedAppIds = includes,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // --- kill switch must never be defeated by an escape -----------------
+
+    @Test
+    fun killSwitchNeverEscapesRegardlessOfConnectivityOrIncludes() {
+        // This is the CRITICAL regression the first-pass fix introduced:
+        // `!connected -> ESCAPE` silently released user traffic to the ISP in
+        // the clear while the kill switch was on. Escaping is never correct
+        // while the user asked for capture-without-exit.
+        for (connected in listOf(false, true)) {
+            for (connectRequested in listOf(false, true)) {
+                for (includes in listOf(emptySet(), someIncludes)) {
+                    val actual = mode(
+                        offline = false,
+                        connected = connected,
+                        killSwitch = true,
+                        connectRequested = connectRequested,
+                        includedAppIds = includes,
+                    )
+                    assertNotEquals(
+                        "kill switch must never escape (that leaks to the ISP): " +
+                            describe(false, connected, true, connectRequested, includes),
+                        VpnPacketFlowMode.ESCAPE,
+                        actual,
+                    )
+                    assertEquals(
+                        "kill switch must honour per-app includes: " +
+                            describe(false, connected, true, connectRequested, includes),
+                        if (includes.isEmpty()) {
+                            VpnPacketFlowMode.DENYLIST
+                        } else {
+                            VpnPacketFlowMode.PER_APP_ALLOWLIST
+                        },
+                        actual,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun connectedWithKillSwitchRoutesToDenylist() {
+        assertEquals(
+            "kill switch plus a live exit is ordinary full capture",
+            VpnPacketFlowMode.DENYLIST,
+            mode(connected = true, killSwitch = true),
+        )
+    }
+
+    @Test
+    fun connectedWithKillSwitchAndIncludesRoutesToPerAppAllowlist() {
+        assertEquals(
+            "per-app includes still take precedence under the kill switch",
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            mode(connected = true, killSwitch = true, includedAppIds = someIncludes),
+        )
+    }
+
+    // --- connect intent must never be defeated by an escape --------------
+
+    @Test
+    fun connectRequestedNeverEscapesRegardlessOfConnectivityOrIncludes() {
+        // `connected` is a liveness signal (providerStateAdded > 0) that can
+        // momentarily empty during attach or provider rotation. Intent does
+        // not flap, so a dip must not drop the user's traffic onto the ISP.
+        for (connected in listOf(false, true)) {
+            for (killSwitch in listOf(false, true)) {
+                for (includes in listOf(emptySet(), someIncludes)) {
+                    val actual = mode(
+                        offline = false,
+                        connected = connected,
+                        killSwitch = killSwitch,
+                        connectRequested = true,
+                        includedAppIds = includes,
+                    )
+                    assertNotEquals(
+                        "connect intent must never escape: " +
+                            describe(false, connected, killSwitch, true, includes),
+                        VpnPacketFlowMode.ESCAPE,
+                        actual,
+                    )
+                    assertEquals(
+                        "connect intent must honour per-app includes: " +
+                            describe(false, connected, killSwitch, true, includes),
+                        if (includes.isEmpty()) {
+                            VpnPacketFlowMode.DENYLIST
+                        } else {
+                            VpnPacketFlowMode.PER_APP_ALLOWLIST
+                        },
+                        actual,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun connectedWithConnectRequestedRoutesToDenylist() {
+        assertEquals(
+            "the normal connected-client state is full capture",
+            VpnPacketFlowMode.DENYLIST,
+            mode(connected = true, connectRequested = true),
+        )
+    }
+
+    @Test
+    fun connectedWithConnectRequestedAndIncludesRoutesToPerAppAllowlist() {
+        assertEquals(
+            "the normal connected-client state with includes is allowlist capture",
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            mode(connected = true, connectRequested = true, includedAppIds = someIncludes),
+        )
+    }
+
+    // --- the reported user scenario, and its non-buggy neighbours --------
+
+    @Test
+    fun provideAlwaysWithoutClientConnectionEscapesInsteadOfBlackholingDns() {
+        // v2026.8.17 user report: provide mode "Always" holds the TUN up
+        // whenever on a network. Not connected as a client, no kill switch, no
+        // connect intent => every other app was captured into a tunnel with no
+        // egress and lost DNS. That state must escape.
+        assertEquals(
+            "provide-only with no live exit must not capture other apps",
+            VpnPacketFlowMode.ESCAPE,
+            mode(offline = false, connected = false, killSwitch = false, connectRequested = false),
+        )
+    }
+
+    @Test
+    fun provideAlwaysWithoutClientConnectionEscapesEvenWithPerAppIncludes() {
+        assertEquals(
+            "stale per-app includes must not resurrect capture with no live exit",
+            VpnPacketFlowMode.ESCAPE,
+            mode(
+                offline = false,
+                connected = false,
+                killSwitch = false,
+                connectRequested = false,
+                includedAppIds = someIncludes,
+            ),
+        )
+    }
+
+    @Test
+    fun provideWithLiveRelayDoesNotEscape() {
+        // Provide/relay regression guard: once there is a live exit the tunnel
+        // is useful again, so it must go back to capturing. Escaping here
+        // would silently disable the VPN for a connected user.
+        assertNotEquals(
+            "a live exit must never escape",
+            VpnPacketFlowMode.ESCAPE,
+            mode(offline = false, connected = true, killSwitch = false, connectRequested = false),
+        )
+        assertEquals(
+            "a live exit with no includes is denylist capture",
+            VpnPacketFlowMode.DENYLIST,
+            mode(offline = false, connected = true, killSwitch = false, connectRequested = false),
+        )
+        assertEquals(
+            "a live exit with includes is allowlist capture",
+            VpnPacketFlowMode.PER_APP_ALLOWLIST,
+            mode(
+                offline = false,
+                connected = true,
+                killSwitch = false,
+                connectRequested = false,
+                includedAppIds = someIncludes,
+            ),
+        )
+    }
+
+    @Test
+    fun escapeRequiresAllThreeCaptureReasonsToBeAbsent() {
+        // Exhaustive online sweep: ESCAPE is reachable online only from the
+        // single provide-only state. Any other online escape is a leak.
+        for (connected in listOf(false, true)) {
+            for (killSwitch in listOf(false, true)) {
+                for (connectRequested in listOf(false, true)) {
+                    for (includes in listOf(emptySet(), someIncludes)) {
+                        val escaped = mode(
+                            offline = false,
+                            connected = connected,
+                            killSwitch = killSwitch,
+                            connectRequested = connectRequested,
+                            includedAppIds = includes,
+                        ) == VpnPacketFlowMode.ESCAPE
+                        assertEquals(
+                            "online escape is allowed only when nothing wants capture: " +
+                                describe(false, connected, killSwitch, connectRequested, includes),
+                            !connected && !killSwitch && !connectRequested,
+                            escaped,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // --- the complete 5-input truth table, written out by hand -----------
+
+    private data class ModeCase(
+        val offline: Boolean,
+        val connected: Boolean,
+        val killSwitch: Boolean,
+        val connectRequested: Boolean,
+        val hasIncludes: Boolean,
+        val expected: VpnPacketFlowMode,
+    )
+
+    @Test
+    fun fullTruthTableMatchesTheCorrectedSemantics() {
+        val escape = VpnPacketFlowMode.ESCAPE
+        val denylist = VpnPacketFlowMode.DENYLIST
+        val allowlist = VpnPacketFlowMode.PER_APP_ALLOWLIST
+        val cases = listOf(
+            // online (offline = false)
+            ModeCase(offline = false, connected = false, killSwitch = false, connectRequested = false, hasIncludes = false, expected = escape),
+            ModeCase(offline = false, connected = false, killSwitch = false, connectRequested = false, hasIncludes = true, expected = escape),
+            ModeCase(offline = false, connected = false, killSwitch = false, connectRequested = true, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = false, killSwitch = false, connectRequested = true, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = false, killSwitch = true, connectRequested = false, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = false, killSwitch = true, connectRequested = false, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = false, killSwitch = true, connectRequested = true, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = false, killSwitch = true, connectRequested = true, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = true, killSwitch = false, connectRequested = false, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = true, killSwitch = false, connectRequested = false, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = true, killSwitch = false, connectRequested = true, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = true, killSwitch = false, connectRequested = true, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = true, killSwitch = true, connectRequested = false, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = true, killSwitch = true, connectRequested = false, hasIncludes = true, expected = allowlist),
+            ModeCase(offline = false, connected = true, killSwitch = true, connectRequested = true, hasIncludes = false, expected = denylist),
+            ModeCase(offline = false, connected = true, killSwitch = true, connectRequested = true, hasIncludes = true, expected = allowlist),
+            // offline (offline = true): always escape
+            ModeCase(offline = true, connected = false, killSwitch = false, connectRequested = false, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = false, connectRequested = false, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = false, connectRequested = true, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = false, connectRequested = true, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = true, connectRequested = false, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = true, connectRequested = false, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = true, connectRequested = true, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = false, killSwitch = true, connectRequested = true, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = false, connectRequested = false, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = false, connectRequested = false, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = false, connectRequested = true, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = false, connectRequested = true, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = true, connectRequested = false, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = true, connectRequested = false, hasIncludes = true, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = true, connectRequested = true, hasIncludes = false, expected = escape),
+            ModeCase(offline = true, connected = true, killSwitch = true, connectRequested = true, hasIncludes = true, expected = escape),
+        )
+
+        assertEquals("the table must cover all 2^5 input combinations", 32, cases.size)
+        assertEquals(
+            "each combination must appear exactly once",
+            32,
+            cases.map { it.copy(expected = escape) }.toSet().size,
+        )
+        for (case in cases) {
+            val includes = if (case.hasIncludes) someIncludes else emptySet()
+            assertEquals(
+                "truth table row: " +
+                    describe(case.offline, case.connected, case.killSwitch, case.connectRequested, includes),
+                case.expected,
+                mode(
+                    offline = case.offline,
+                    connected = case.connected,
+                    killSwitch = case.killSwitch,
+                    connectRequested = case.connectRequested,
+                    includedAppIds = includes,
+                ),
+            )
+        }
+    }
+
+    // --- the new fields must be material state (they drive the rebuild) --
+
+    @Test
+    fun activePacketFlowRebuildsWhenKillSwitchIsToggled() {
+        // If killSwitch were left out of the configuration's equality, turning
+        // the kill switch on while the tunnel was escaping would never rebuild
+        // the TUN, and the kill switch would silently do nothing.
+        val applied = configuration(connected = false, killSwitch = false)
+        val desired = configuration(connected = false, killSwitch = true)
+
+        assertTrue(
+            "toggling the kill switch must rebuild the packet flow",
+            vpnPacketFlowNeedsRebuild(true, applied, desired),
+        )
+    }
+
+    @Test
+    fun activePacketFlowRebuildsWhenConnectIsRequested() {
+        val applied = configuration(connected = false, connectRequested = false)
+        val desired = configuration(connected = false, connectRequested = true)
+
+        assertTrue(
+            "requesting connect must rebuild the packet flow",
+            vpnPacketFlowNeedsRebuild(true, applied, desired),
+        )
+    }
+
+    @Test
+    fun configurationCarriesTheCaptureIntentThroughToTheMode() {
+        // End-to-end over the data class: the same snapshot that the service
+        // diffs for rebuilds is the one that decides the mode.
+        val provideOnly = configuration(connected = false)
+        val killSwitchOn = configuration(connected = false, killSwitch = true)
+
+        assertEquals(
+            "provide-only snapshot escapes",
+            VpnPacketFlowMode.ESCAPE,
+            vpnPacketFlowMode(
+                offline = provideOnly.offline,
+                connected = provideOnly.connected,
+                killSwitch = provideOnly.killSwitch,
+                connectRequested = provideOnly.connectRequested,
+                includedAppIds = provideOnly.includedAppIds,
+            ),
+        )
+        assertEquals(
+            "kill-switch snapshot captures",
+            VpnPacketFlowMode.DENYLIST,
+            vpnPacketFlowMode(
+                offline = killSwitchOn.offline,
+                connected = killSwitchOn.connected,
+                killSwitch = killSwitchOn.killSwitch,
+                connectRequested = killSwitchOn.connectRequested,
+                includedAppIds = killSwitchOn.includedAppIds,
+            ),
+        )
+        assertNotEquals(
+            "the two snapshots must not compare equal",
+            provideOnly,
+            killSwitchOn,
         )
     }
 }


### PR DESCRIPTION
# Fix: provide mode "Always" blackholes DNS when not connected as client

## Bug

When provide mode is set to Always and the device is not connected as a client (it is only relaying for other users), the app kept every other app's traffic routed into the VPN tunnel. With no live UR exit, those apps' DNS stopped resolving. The whole phone lost internet. Users on 2026.8.17 reported this.

Provide mode Always is meant to keep the tunnel up whenever the device is on a network, so it stays ready to relay for peers. It must not route the device's own apps into a tunnel that has no exit.

Before this fix: provide=Always with no client connection took the whole phone offline. After this fix: provide=Always stays ready to relay for peers, and the phone's own apps keep working until a live UR connection exists.

## Root cause

`MainService.updatePfd()` chose routing from the offline flag alone. It did not account for why the tunnel was up (provide, connect, or kill switch) or whether a live provider exit existed. In the provide-only, not-connected state it fell through to the deny-list branch and captured every app, blackholing DNS. Version 7.22 gated capture on the offline state only, and its own escape path never reliably worked. This change restores that intent-gating and fixes the escape path itself.

## Change

1. `vpnPacketFlowMode()` is now a pure function that decides routing from device state. It only escapes other apps when the device is offline, or when the tunnel is up purely for provide with no live exit, no kill switch, and no connect request. A kill-switch user never escapes, so their traffic stays held and does not leak to the ISP. A user requesting connect never escapes during a transient provider dip. When a live exit appears, the tunnel rebuilds into deny-list or allow-list mode and capture resumes.
2. The escape no longer relies on an allow-listed package that no build ships (which threw before the tunnel came up). It now builds the tunnel from an address only: no routes, no DNS, and both address families unblocked. Android routes nothing into it, so every app keeps its native network path. This also fixes the same issue in the existing offline path.
3. The OS-level Android Always-on VPN setting is unchanged. That path uses a separate fail-closed guard by design, so this is scoped to app-level provide=Always.
4. The tunnel always establishes, even when the SDK supplies no tunnel address. It falls back to a documentation address, so kill-switch and connected states cannot fail open to the ISP.

## Tests

Added 39 unit tests for `vpnPacketFlowMode()`, covering offline, kill switch, connect-requested, and per-app include/deny combinations, including an exhaustive truth table and an escape sweep. They run on a plain JVM and need no Android runtime. Removing either gate breaks the tests, so they are load-bearing.

On-device verification is not complete. I could not build a test APK because the app needs a private Go SDK build that is not available to me. Check on a device before release: provide Always with no connection, then confirm other apps resolve DNS and a live connection still routes through the tunnel.