### PR TITLE
fix: do not crash at launch when the SDK cannot set the log directory

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -220,7 +220,16 @@ class MainApplication : Application() {
         }
 
         val path: String = applicationContext.filesDir.absolutePath
-        Sdk.setLogDir(path)
+        // gomobile binds the Go error return as a checked java exception, which
+        // kotlin does not enforce -- so unguarded, a log dir that cannot be
+        // written (storage full, quota, EIO) propagates straight out of
+        // onCreate as an unhandled crash on every launch. Logging must never be
+        // what breaks a launch: glog keeps whatever destination it already had.
+        try {
+            Sdk.setLogDir(path)
+        } catch (e: Exception) {
+            Log.i(TAG, "could not set the log dir to $path: ${e.message}")
+        }
 
         val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager?
         val maxMemoryMib = activityManager?.memoryClass?.toLong() ?: 32


### PR DESCRIPTION
One file, +10/−1.

`MainApplication.onCreate` calls `Sdk.setLogDir(path)` unguarded. gomobile binds that Go function's `error` return as a checked Java exception, and Kotlin does not enforce checked exceptions — so it compiles, and then a log directory that cannot be written (storage full, quota, EIO) propagates straight out of `onCreate` as **an unhandled crash on every launch**.

The SDK's own doc comment states the opposite intent: logging must never be what breaks a launch. glog keeps whatever destination it already had, so continuing is safe.

```kotlin
try {
    Sdk.setLogDir(path)
} catch (e: Exception) {
    Log.i(TAG, "could not set the log dir to $path: ${e.message}")
}
```

Which function is called is unchanged — this is purely the guard.

## Verification

Honestly: **this was not compiled locally.** The machine it was written on has no JDK and no Android SDK/NDK (`java -version` fails, `ANDROID_HOME` unset). It was verified by reading — the caught type is right for a gomobile-bound throwing call, imports are present, brace balance confirmed, and the diff touches exactly one file with no trailing whitespace. **This PR's CI run is its first real compile check**, which given the size seems a reasonable trade, but worth stating rather than implying otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)