### PR TITLE
feat: per-process glog root, and migrate pre-upgrade log files into it

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/DiagnosticsLogLocation.kt
+++ b/app/app/src/main/java/com/bringyour/network/DiagnosticsLogLocation.kt
@@ -1,0 +1,80 @@
+package com.bringyour.network
+
+import java.io.File
+
+/**
+ * Where each process writes its logs.
+ *
+ * The sdk prunes per directory -- `clearOldLogs` keeps the 4 newest files in
+ * whichever directory glog is pointed at -- so processes that share one
+ * directory delete each other's history. Android is single-process (no
+ * `android:process` in the manifest), so "app" is the only subdirectory that
+ * ever appears here; the layout still matches iOS, which really does have two
+ * writers (the app and the network extension), so both platforms make the
+ * same sdk call and lay their logs out the same way.
+ */
+const val APP_LOG_PROCESS_NAME = "app"
+
+/** The shared log root: one subdirectory per writing process. */
+fun logRootDir(filesDir: File): File = File(filesDir, "logs")
+
+/** glog's severity tags, as they appear in a file name after ".log.". */
+private val LOG_FILE_SEVERITIES = listOf("INFO", "WARNING", "ERROR", "FATAL")
+
+/**
+ * True for a name glog wrote, i.e.
+ * `<program>.<host>.<user>.log.<SEVERITY>.<time>.<pid>`.
+ */
+fun isGlogFileName(name: String): Boolean =
+    LOG_FILE_SEVERITIES.any { name.contains(".log.$it") }
+
+/**
+ * Moves pre-upgrade log files out of `filesDir` into the per-process log
+ * directory, returning how many were relocated.
+ *
+ * Builds before the per-process root wrote glog files directly into
+ * `filesDir`. Retention only ever prunes the directory glog is currently
+ * pointed at (`clearOldLogs`, sdk/sdk.go), so once the root moves those files
+ * are never touched again: up to four files of up to 16MB each stranded in
+ * `filesDir` forever on every upgrading install.
+ * They are also unreachable evidence. Every reader of the logs resolves them
+ * through `Sdk.getLogDir()` -- the feedback screen's share and export buttons
+ * do today -- and that now names `<filesDir>/logs/<process>`, so a user who
+ * upgrades and then reports an incident that predates the upgrade attaches
+ * none of the logs that recorded it.
+ *
+ * Moving rather than deleting keeps those logs reachable, and doing it BEFORE
+ * `Sdk.setLogDirForProcess` hands the merged set to that same retention pass
+ * -- which keeps the four newest and drops the rest -- so this bounds the
+ * storage rather than doubling it.
+ */
+fun migrateLegacyLogFiles(filesDir: File, processLogDir: File): Int {
+    val legacy = filesDir.listFiles()?.filter { it.isFile && isGlogFileName(it.name) } ?: return 0
+    if (legacy.isEmpty()) {
+        return 0
+    }
+    if (!processLogDir.isDirectory && !processLogDir.mkdirs()) {
+        return 0
+    }
+
+    var moved = 0
+    for (file in legacy) {
+        val dest = File(processLogDir, file.name)
+        if (dest.exists()) {
+            // glog names embed host, pid and start time, so a collision means
+            // an earlier launch already migrated this file: the copy still
+            // sitting in filesDir is the redundant one.
+            if (file.delete()) {
+                moved += 1
+            }
+            continue
+        }
+        // A rename that fails leaves the file exactly where it was, which is
+        // no worse than never having run. Never delete a log we could not
+        // move -- the whole point is that it stays reachable.
+        if (file.renameTo(dest)) {
+            moved += 1
+        }
+    }
+    return moved
+}

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -29,6 +29,7 @@ import com.bringyour.sdk.NetworkSpace
 import com.bringyour.sdk.Sdk
 import com.bringyour.sdk.Sub
 import dagger.hilt.android.HiltAndroidApp
+import java.io.File
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 import kotlin.math.min
@@ -219,16 +220,49 @@ class MainApplication : Application() {
             Sdk.setMemoryProfileRate(BuildConfig.URNETWORK_MEMORY_PROFILE_RATE_BYTES)
         }
 
-        val path: String = applicationContext.filesDir.absolutePath
-        // gomobile binds the Go error return as a checked java exception, which
-        // kotlin does not enforce -- so unguarded, a log dir that cannot be
-        // written (storage full, quota, EIO) propagates straight out of
-        // onCreate as an unhandled crash on every launch. Logging must never be
-        // what breaks a launch: glog keeps whatever destination it already had.
-        try {
-            Sdk.setLogDir(path)
+        // One subdirectory per writing process, under a shared root. Android is
+        // single-process (no android:process in the manifest), so there is only
+        // ever "app" here -- but the sdk prunes per directory (it keeps the 4
+        // newest files in whichever one glog is pointed at), so the per-process
+        // layout is what stops two writers from deleting each other's history,
+        // and it keeps this call identical to the one iOS makes.
+        val logRoot = logRootDir(applicationContext.filesDir)
+        val processLogDir = File(logRoot, APP_LOG_PROCESS_NAME)
+
+        // Pre-upgrade builds wrote glog files straight into filesDir. Nothing
+        // ever prunes or reads that directory again once the root moves, so
+        // the old files are both dead storage and unreachable evidence. Run the
+        // migration BEFORE pointing glog at the new directory: the sdk's
+        // retention pass then treats the migrated files as part of the app's
+        // own history and keeps only the newest four of the merged set.
+        val migratedLogCount = try {
+            migrateLegacyLogFiles(applicationContext.filesDir, processLogDir)
         } catch (e: Exception) {
-            Log.i(TAG, "could not set the log dir to $path: ${e.message}")
+            Log.e(TAG, "could not migrate pre-upgrade log files: ${e.message}", e)
+            0
+        }
+        if (0 < migratedLogCount) {
+            Log.i(TAG, "migrated $migratedLogCount pre-upgrade log files into $processLogDir")
+        }
+
+        // gomobile binds Go's `error` return as a checked java exception, and
+        // kotlin does not enforce checked exceptions -- so an unguarded call
+        // compiles and then propagates out of Application.onCreate as an
+        // unhandled crash on EVERY launch. The sdk's own contract is the
+        // opposite ("logging must never be what breaks a launch"), but the
+        // fallback meant to make the error unreachable cannot do that here: it
+        // targets os.TempDir(), which on android resolves to /data/local/tmp
+        // (Go's own android case in os.tempDir, since app processes have no
+        // TMPDIR set) -- shell-owned and not writable by an app uid. So if
+        // <filesDir>/logs cannot be created (storage full, quota, EIO) the
+        // fallback fails too and the error really is returned.
+        // Catching it turns an unbootable app back into a logging problem:
+        // glog keeps whatever destination it already had, and Sdk.getLogDir()
+        // keeps naming that destination for the feedback screen's log buttons.
+        try {
+            Sdk.setLogDirForProcess(logRoot.absolutePath, APP_LOG_PROCESS_NAME)
+        } catch (e: Exception) {
+            Log.e(TAG, "could not point logging at $logRoot: ${e.message}", e)
         }
 
         val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager?

--- a/app/app/src/test/java/com/bringyour/network/DiagnosticsLogLocationTest.kt
+++ b/app/app/src/test/java/com/bringyour/network/DiagnosticsLogLocationTest.kt
@@ -1,0 +1,90 @@
+package com.bringyour.network
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DiagnosticsLogLocationTest {
+
+    private lateinit var filesDir: File
+
+    @Before
+    fun setUp() {
+        filesDir = Files.createTempDirectory("filesDir").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        filesDir.deleteRecursively()
+    }
+
+    private fun processLogDir(): File = File(logRootDir(filesDir), APP_LOG_PROCESS_NAME)
+
+    @Test
+    fun theLogRootIsASubdirectoryOfFilesDirPerProcess() {
+        assertEquals(File(filesDir, "logs"), logRootDir(filesDir))
+        // the directory name is the label for which process wrote a file, and
+        // it is the same one iOS uses for its app process
+        assertEquals("app", APP_LOG_PROCESS_NAME)
+    }
+
+    @Test
+    fun glogFileNamesAreRecognisedByTheirSeverity() {
+        assertTrue(isGlogFileName("urnetwork.host.user.log.INFO.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.WARNING.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.ERROR.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.FATAL.20260101-000000.1234"))
+        assertFalse(isGlogFileName("shared_prefs.xml"))
+        assertFalse(isGlogFileName("urnetwork.log"))
+        assertFalse(isGlogFileName("localstate.db"))
+    }
+
+    @Test
+    fun preUpgradeLogsAreMovedUnderTheProcessRootRatherThanStranded() {
+        // the old build wrote glog files straight into filesDir; nothing prunes
+        // or exports that directory once the root moves, so those files were
+        // both dead storage and unreachable evidence
+        val legacy = File(filesDir, "urnetwork.host.user.log.INFO.20260101-000000.1234")
+        legacy.writeText("pre-upgrade line")
+        val other = File(filesDir, "localstate.db")
+        other.writeText("not a log")
+
+        assertEquals(1, migrateLegacyLogFiles(filesDir, processLogDir()))
+
+        assertFalse("the legacy copy must not be left behind", legacy.exists())
+        val moved = File(processLogDir(), legacy.name)
+        assertTrue("the log must still be exportable", moved.exists())
+        assertEquals("pre-upgrade line", moved.readText())
+        assertTrue("only glog files are touched", other.exists())
+    }
+
+    @Test
+    fun migratingIsIdempotentAndNeverOverwritesALiveLog() {
+        val name = "urnetwork.host.user.log.INFO.20260101-000000.1234"
+        val live = File(processLogDir(), name)
+        assertTrue(processLogDir().mkdirs())
+        live.writeText("the file already under the new root")
+        val legacy = File(filesDir, name)
+        legacy.writeText("the stale duplicate")
+
+        assertEquals(1, migrateLegacyLogFiles(filesDir, processLogDir()))
+
+        assertFalse(legacy.exists())
+        assertEquals("the file already under the new root", live.readText())
+
+        // a second launch has nothing left to do
+        assertEquals(0, migrateLegacyLogFiles(filesDir, processLogDir()))
+    }
+
+    @Test
+    fun anInstallWithNoLegacyLogsIsUntouched() {
+        assertEquals(0, migrateLegacyLogFiles(filesDir, processLogDir()))
+        // no destination directory is created for nothing
+        assertFalse(processLogDir().exists())
+    }
+}


### PR DESCRIPTION
3 files, +212/−8. First of three stacked Android PRs. Needs urnetwork/sdk#149 (merged).

Switches `MainApplication` from `Sdk.setLogDir(filesDir)` to `Sdk.setLogDirForProcess(<filesDir>/logs, "app")`, keeping the try/catch guard from #473.

## The migration is the part that matters

Pre-upgrade builds wrote glog files straight into `filesDir`. Once the root moves, nothing ever prunes or exports that directory again — so the old files become **both dead storage** (up to ~64 MB: 4 files × the 16 MiB cap) **and unreachable evidence**. A user who upgrades and then exports to report an incident predating the upgrade would get none of the logs that recorded it.

The migration runs **before** glog is pointed at the new directory, so the SDK's retention pass treats the moved files as part of the app's own history and keeps the newest four of the merged set. Running it first also means glog isn't yet writing into `filesDir` in this process, so the renames can't race a live file handle.

## Behaviour change worth knowing

`FeedbackScreen`'s existing Share/Export log buttons read `Sdk.getLogDir()`, which now returns `<filesDir>/logs/app` rather than `<filesDir>`. That's the intended outcome, and the migration is precisely what keeps those buttons showing pre-upgrade logs.

`res/xml/file_paths.xml` already declares `<files-path name="logs" path="."/>` (the whole `filesDir`), so FileProvider still resolves the new subdirectory with no manifest change.

## One-way door, stated plainly

The migration is a one-way rename with no rollback: a user who downgrades to a pre-upgrade build won't see the moved files, since the old build reads `filesDir` directly. That seems clearly right — the alternative strands them permanently — but it is a real one-way door and isn't covered by a test.

## Verification

**Not compiled locally** — no JDK, Android SDK or NDK available. This PR's CI run is the first place the Kotlin compiler and the four new tests actually execute. Verified by inspection: every SDK symbol greped against the Go source at `sdk@main` (including confirming `SetLogDirForProcess` really can return an error, so the guard isn't dead code), brace/paren balance, overload resolution, and all four tests walked by hand against the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)