### PR TITLE
feat: runtime log verbosity control on the developer screen

### DIFF
--- a/app/app/src/main/java/com/bringyour/network/DiagnosticsLogLocation.kt
+++ b/app/app/src/main/java/com/bringyour/network/DiagnosticsLogLocation.kt
@@ -1,0 +1,80 @@
+package com.bringyour.network
+
+import java.io.File
+
+/**
+ * Where each process writes its logs.
+ *
+ * The sdk prunes per directory -- `clearOldLogs` keeps the 4 newest files in
+ * whichever directory glog is pointed at -- so processes that share one
+ * directory delete each other's history. Android is single-process (no
+ * `android:process` in the manifest), so "app" is the only subdirectory that
+ * ever appears here; the layout still matches iOS, which really does have two
+ * writers (the app and the network extension), so both platforms make the
+ * same sdk call and lay their logs out the same way.
+ */
+const val APP_LOG_PROCESS_NAME = "app"
+
+/** The shared log root: one subdirectory per writing process. */
+fun logRootDir(filesDir: File): File = File(filesDir, "logs")
+
+/** glog's severity tags, as they appear in a file name after ".log.". */
+private val LOG_FILE_SEVERITIES = listOf("INFO", "WARNING", "ERROR", "FATAL")
+
+/**
+ * True for a name glog wrote, i.e.
+ * `<program>.<host>.<user>.log.<SEVERITY>.<time>.<pid>`.
+ */
+fun isGlogFileName(name: String): Boolean =
+    LOG_FILE_SEVERITIES.any { name.contains(".log.$it") }
+
+/**
+ * Moves pre-upgrade log files out of `filesDir` into the per-process log
+ * directory, returning how many were relocated.
+ *
+ * Builds before the per-process root wrote glog files directly into
+ * `filesDir`. Retention only ever prunes the directory glog is currently
+ * pointed at (`clearOldLogs`, sdk/sdk.go), so once the root moves those files
+ * are never touched again: up to four files of up to 16MB each stranded in
+ * `filesDir` forever on every upgrading install.
+ * They are also unreachable evidence. Every reader of the logs resolves them
+ * through `Sdk.getLogDir()` -- the feedback screen's share and export buttons
+ * do today -- and that now names `<filesDir>/logs/<process>`, so a user who
+ * upgrades and then reports an incident that predates the upgrade attaches
+ * none of the logs that recorded it.
+ *
+ * Moving rather than deleting keeps those logs reachable, and doing it BEFORE
+ * `Sdk.setLogDirForProcess` hands the merged set to that same retention pass
+ * -- which keeps the four newest and drops the rest -- so this bounds the
+ * storage rather than doubling it.
+ */
+fun migrateLegacyLogFiles(filesDir: File, processLogDir: File): Int {
+    val legacy = filesDir.listFiles()?.filter { it.isFile && isGlogFileName(it.name) } ?: return 0
+    if (legacy.isEmpty()) {
+        return 0
+    }
+    if (!processLogDir.isDirectory && !processLogDir.mkdirs()) {
+        return 0
+    }
+
+    var moved = 0
+    for (file in legacy) {
+        val dest = File(processLogDir, file.name)
+        if (dest.exists()) {
+            // glog names embed host, pid and start time, so a collision means
+            // an earlier launch already migrated this file: the copy still
+            // sitting in filesDir is the redundant one.
+            if (file.delete()) {
+                moved += 1
+            }
+            continue
+        }
+        // A rename that fails leaves the file exactly where it was, which is
+        // no worse than never having run. Never delete a log we could not
+        // move -- the whole point is that it stays reachable.
+        if (file.renameTo(dest)) {
+            moved += 1
+        }
+    }
+    return moved
+}

--- a/app/app/src/main/java/com/bringyour/network/MainApplication.kt
+++ b/app/app/src/main/java/com/bringyour/network/MainApplication.kt
@@ -29,6 +29,7 @@ import com.bringyour.sdk.NetworkSpace
 import com.bringyour.sdk.Sdk
 import com.bringyour.sdk.Sub
 import dagger.hilt.android.HiltAndroidApp
+import java.io.File
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 import kotlin.math.min
@@ -219,16 +220,49 @@ class MainApplication : Application() {
             Sdk.setMemoryProfileRate(BuildConfig.URNETWORK_MEMORY_PROFILE_RATE_BYTES)
         }
 
-        val path: String = applicationContext.filesDir.absolutePath
-        // gomobile binds the Go error return as a checked java exception, which
-        // kotlin does not enforce -- so unguarded, a log dir that cannot be
-        // written (storage full, quota, EIO) propagates straight out of
-        // onCreate as an unhandled crash on every launch. Logging must never be
-        // what breaks a launch: glog keeps whatever destination it already had.
-        try {
-            Sdk.setLogDir(path)
+        // One subdirectory per writing process, under a shared root. Android is
+        // single-process (no android:process in the manifest), so there is only
+        // ever "app" here -- but the sdk prunes per directory (it keeps the 4
+        // newest files in whichever one glog is pointed at), so the per-process
+        // layout is what stops two writers from deleting each other's history,
+        // and it keeps this call identical to the one iOS makes.
+        val logRoot = logRootDir(applicationContext.filesDir)
+        val processLogDir = File(logRoot, APP_LOG_PROCESS_NAME)
+
+        // Pre-upgrade builds wrote glog files straight into filesDir. Nothing
+        // ever prunes or reads that directory again once the root moves, so
+        // the old files are both dead storage and unreachable evidence. Run the
+        // migration BEFORE pointing glog at the new directory: the sdk's
+        // retention pass then treats the migrated files as part of the app's
+        // own history and keeps only the newest four of the merged set.
+        val migratedLogCount = try {
+            migrateLegacyLogFiles(applicationContext.filesDir, processLogDir)
         } catch (e: Exception) {
-            Log.i(TAG, "could not set the log dir to $path: ${e.message}")
+            Log.e(TAG, "could not migrate pre-upgrade log files: ${e.message}", e)
+            0
+        }
+        if (0 < migratedLogCount) {
+            Log.i(TAG, "migrated $migratedLogCount pre-upgrade log files into $processLogDir")
+        }
+
+        // gomobile binds Go's `error` return as a checked java exception, and
+        // kotlin does not enforce checked exceptions -- so an unguarded call
+        // compiles and then propagates out of Application.onCreate as an
+        // unhandled crash on EVERY launch. The sdk's own contract is the
+        // opposite ("logging must never be what breaks a launch"), but the
+        // fallback meant to make the error unreachable cannot do that here: it
+        // targets os.TempDir(), which on android resolves to /data/local/tmp
+        // (Go's own android case in os.tempDir, since app processes have no
+        // TMPDIR set) -- shell-owned and not writable by an app uid. So if
+        // <filesDir>/logs cannot be created (storage full, quota, EIO) the
+        // fallback fails too and the error really is returned.
+        // Catching it turns an unbootable app back into a logging problem:
+        // glog keeps whatever destination it already had, and Sdk.getLogDir()
+        // keeps naming that destination for the feedback screen's log buttons.
+        try {
+            Sdk.setLogDirForProcess(logRoot.absolutePath, APP_LOG_PROCESS_NAME)
+        } catch (e: Exception) {
+            Log.e(TAG, "could not point logging at $logRoot: ${e.message}", e)
         }
 
         val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager?

--- a/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperScreen.kt
@@ -46,6 +46,8 @@ import com.bringyour.network.ui.components.URTextInputLabel
 import com.bringyour.network.ui.theme.Black
 import com.bringyour.network.ui.theme.BlueMedium
 import com.bringyour.network.ui.theme.MainTintedBackgroundBase
+import com.bringyour.network.ui.theme.RedDark
+import com.bringyour.network.ui.theme.TextDanger
 import com.bringyour.network.ui.theme.TextMuted
 import com.bringyour.network.ui.theme.TopBarTitleTextStyle
 import com.bringyour.network.utils.formatByteCountCompact
@@ -136,6 +138,44 @@ private fun DeveloperContent(developerViewModel: DeveloperViewModel) {
     // absence of. The export tolerates a null device on its own
     // (deviceManager.device?.let { ... }), which is what makes that safe.
     URTextInputLabel(text = stringResource(id = R.string.dev_section_diagnostics))
+
+    // ABOVE the export rows on purpose: the order of operations is set the
+    // level, reproduce the fault, then export. A verbosity control placed
+    // under the export actions is found only after the capture it was supposed
+    // to widen, and the bundle it produced is the useless one -- close to half
+    // the log statements in `connect` (roughly 290 of some 700), every
+    // contract, transport and window line among them, sit behind V(1)/V(2) and
+    // are simply not written at level 0.
+    DeveloperVerbositySetting(
+        level = developerViewModel.logVerbosity,
+        onSelect = developerViewModel.setLogVerbosity,
+    )
+
+    // Persistent, not a one-shot toast: it has to be on screen at the moment
+    // the user reaches for "Export all logs (raw)", which can be many minutes
+    // after the level was raised. This pairing is the point -- raising the
+    // verbosity is what makes the redaction stop being decorative, so the
+    // warning names the redacted export rather than just describing the risk.
+    if (logVerbosityRecordsDestinations(developerViewModel.logVerbosity)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+                .background(RedDark, RoundedCornerShape(8.dp))
+                .padding(12.dp),
+        ) {
+            Text(
+                stringResource(id = R.string.dev_log_verbosity_warning_title),
+                style = MaterialTheme.typography.bodyMedium,
+                color = TextDanger,
+            )
+            Text(
+                stringResource(id = R.string.dev_log_verbosity_warning),
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White,
+            )
+        }
+    }
 
     val context = LocalContext.current
     val shareBundle: (File) -> Unit = { file ->
@@ -834,6 +874,87 @@ private fun DeveloperContent(developerViewModel: DeveloperViewModel) {
     }
 
     Spacer(modifier = Modifier.height(32.dp))
+}
+
+/**
+ * The glog verbosity of the process that writes the logs, cycling
+ * Default -> Verbose -> Trace on tap.
+ *
+ * The value shown is the one the DEVICE reports, never the one last asked for.
+ * A set can be clamped by the sdk or refused outright by a hosted device, and
+ * neither throws -- so a level that failed to apply has to be visible here
+ * rather than assumed, or the user reproduces a fault believing they are
+ * capturing V(1) contract accounting and exports a bundle that has none.
+ *
+ * "Unavailable" is not the same as level 0: it means there is no device to ask
+ * yet, so the row is inert rather than reporting a default that is not in
+ * force.
+ */
+@Composable
+private fun DeveloperVerbositySetting(
+    level: Long?,
+    onSelect: (Long) -> Unit,
+) {
+    val named = logVerbosityLevel(level)
+    val name = when (named) {
+        LogVerbosityLevel.DEFAULT -> R.string.dev_log_verbosity_default
+        LogVerbosityLevel.VERBOSE -> R.string.dev_log_verbosity_verbose
+        LogVerbosityLevel.TRACE -> R.string.dev_log_verbosity_trace
+        null -> R.string.dev_log_verbosity_unavailable
+    }
+    // the detail line names what THIS level buys, so the cost of the next step
+    // is read before it is taken rather than discovered in the bundle
+    val detail = when (named) {
+        LogVerbosityLevel.DEFAULT -> R.string.dev_log_verbosity_default_detail
+        LogVerbosityLevel.VERBOSE -> R.string.dev_log_verbosity_verbose_detail
+        LogVerbosityLevel.TRACE -> R.string.dev_log_verbosity_trace_detail
+        null -> R.string.dev_log_verbosity_unavailable_detail
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            // inert with no device: there is nothing to set the level on, and
+            // a tap that appeared to work would leave the row claiming a level
+            // nothing is running at
+            .clickable(enabled = level != null) {
+                onSelect(nextLogVerbosity(level ?: LOG_VERBOSITY_DEFAULT))
+            }
+            .padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth(0.72f)) {
+            Text(
+                stringResource(id = R.string.dev_log_verbosity),
+                style = MaterialTheme.typography.bodyLarge,
+                color = Color.White,
+            )
+            Text(
+                stringResource(id = detail),
+                style = MaterialTheme.typography.bodySmall,
+                color = TextMuted,
+            )
+        }
+        Text(
+            // the number as well as the name -- it is what the sdk reports and
+            // what a support thread compares against the bundle's manifest,
+            // and it is the only place a level outside the sdk's range shows
+            if (level == null) {
+                stringResource(id = name)
+            } else {
+                logVerbosityValueLabel(level, stringResource(id = name))
+            },
+            style = MaterialTheme.typography.bodyLarge,
+            // a level that records real destinations is not an ordinary
+            // setting value, and must not read as one
+            color = when {
+                level == null -> TextMuted
+                logVerbosityRecordsDestinations(level) -> TextDanger
+                else -> BlueMedium
+            },
+        )
+    }
 }
 
 /**

--- a/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperScreen.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperScreen.kt
@@ -1,5 +1,6 @@
 package com.bringyour.network.ui.settings
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -25,11 +26,18 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.bringyour.network.R
@@ -40,8 +48,10 @@ import com.bringyour.network.ui.theme.BlueMedium
 import com.bringyour.network.ui.theme.MainTintedBackgroundBase
 import com.bringyour.network.ui.theme.TextMuted
 import com.bringyour.network.ui.theme.TopBarTitleTextStyle
+import com.bringyour.network.utils.formatByteCountCompact
 import com.bringyour.sdk.Exit
 import kotlinx.coroutines.delay
+import java.io.File
 import java.util.Locale
 
 /**
@@ -115,6 +125,191 @@ private fun DeveloperContent(developerViewModel: DeveloperViewModel) {
         style = MaterialTheme.typography.bodySmall,
         color = TextMuted,
     )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // A diagnostics export is most needed exactly when the connection is
+    // broken or the user is signed out -- i.e. exactly when `connected`
+    // (reliability != null, which requires a live device) is false. This
+    // section therefore renders ABOVE the !connected guard below rather than
+    // being gated on the healthy connection it exists to help diagnose the
+    // absence of. The export tolerates a null device on its own
+    // (deviceManager.device?.let { ... }), which is what makes that safe.
+    URTextInputLabel(text = stringResource(id = R.string.dev_section_diagnostics))
+
+    val context = LocalContext.current
+    val shareBundle: (File) -> Unit = { file ->
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/zip"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(
+            Intent.createChooser(intent, context.getString(R.string.dev_export_share)),
+        )
+    }
+
+    // cacheDir/share is already declared to the FileProvider as "share"
+    // (res/xml/file_paths.xml), so a bundle written there is shareable with no
+    // manifest change. remember{} because a composable body runs on every
+    // recomposition -- and this one recomposes on each reliability/metrics
+    // poll -- while the directory is created by the exporter itself, on
+    // Dispatchers.IO: File.mkdirs() stats the path before it can return, which
+    // is a disk hit the ui thread should never take.
+    val shareDir = remember(context) { File(context.cacheDir, "share") }
+
+    // The bundle comes back as state rather than through a completion lambda:
+    // a lambda declared here captures this composition's Activity, so an
+    // export outliving a rotation would call startActivity on a destroyed one,
+    // and the viewmodel would hold it alive for the whole export.
+    val pendingShare = developerViewModel.pendingShare
+    LaunchedEffect(pendingShare) {
+        pendingShare?.let { file ->
+            shareBundle(file)
+            developerViewModel.consumePendingShare()
+        }
+    }
+
+    // The total size before exporting, and any unavailable source with its
+    // reason, are both shown BEFORE the user commits to a bundle of up to
+    // 4x16MB per process -- not afterwards in the summary. The read is
+    // directory i/o plus a stat per file across the gomobile bridge, so it
+    // happens once on entry, off the main thread.
+    LaunchedEffect(Unit) {
+        developerViewModel.refreshDiagnostics()
+    }
+
+    val exporting = developerViewModel.exporting
+
+    Text(
+        inventoryLabel(developerViewModel.inventory.size, developerViewModel.inventoryByteCount),
+        style = MaterialTheme.typography.bodySmall,
+        color = TextMuted,
+    )
+
+    developerViewModel.unavailableSources.forEach { unavailable ->
+        Text(
+            stringResource(id = R.string.dev_export_unavailable, unavailable),
+            style = MaterialTheme.typography.bodySmall,
+            color = TextMuted,
+        )
+    }
+
+    DeveloperAction(
+        label = stringResource(id = R.string.dev_export_all_logs),
+        enabled = !exporting,
+    ) {
+        developerViewModel.exportDiagnostics(
+            shareDir,
+            redact = false,
+            selected = emptyList(),
+            nowMillis = System.currentTimeMillis(),
+        )
+    }
+
+    DeveloperAction(
+        label = stringResource(id = R.string.dev_export_redacted_logs),
+        enabled = !exporting,
+    ) {
+        developerViewModel.exportDiagnostics(
+            shareDir,
+            redact = true,
+            selected = emptyList(),
+            nowMillis = System.currentTimeMillis(),
+        )
+    }
+
+    var showPicker by remember { mutableStateOf(false) }
+
+    DeveloperAction(
+        label = stringResource(id = R.string.dev_choose_logs),
+        enabled = !exporting && !developerViewModel.refreshingDiagnostics,
+    ) {
+        developerViewModel.refreshDiagnostics()
+        showPicker = !showPicker
+    }
+
+    if (showPicker) {
+        developerViewModel.inventory.forEach { info ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { developerViewModel.toggleLogSelection(info.name) }
+                    .padding(vertical = 6.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    logFileRowLabel(info.source, info.severity, info.byteCount, info.modifiedMillis),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (developerViewModel.selectedLogNames.contains(info.name)) {
+                        BlueMedium
+                    } else {
+                        TextMuted
+                    },
+                )
+            }
+        }
+
+        Text(
+            selectionLabel(
+                developerViewModel.selectedLogNames.size,
+                developerViewModel.selectedByteCount,
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = TextMuted,
+        )
+
+        // Disabled -- and a no-op even if it were somehow tapped -- with
+        // nothing checked, or while an export is already running: an empty
+        // selection means "no filter" to the sdk, which would otherwise export
+        // every log file unredacted, the opposite of what this row's label
+        // promises.
+        DeveloperAction(
+            label = stringResource(id = R.string.dev_export_selected),
+            enabled = !exporting && canExportSelection(developerViewModel.selectedLogNames),
+        ) {
+            developerViewModel.exportSelectedDiagnostics(shareDir, System.currentTimeMillis())
+        }
+    }
+
+    if (exporting) {
+        Text(
+            stringResource(id = R.string.dev_exporting),
+            style = MaterialTheme.typography.bodySmall,
+            color = TextMuted,
+        )
+    }
+
+    developerViewModel.lastExport?.let { lastExport ->
+        // Resolved here rather than in the viewmodel because this is where a
+        // <plurals> can be read: "Exported 1 log files" is a count formatted
+        // into a fixed English phrase, and a selective export of one file is
+        // the common case that produces it.
+        val failure = lastExport.failure
+        Text(
+            if (failure != null) {
+                stringResource(id = R.string.dev_export_failed, failure)
+            } else {
+                pluralStringResource(
+                    id = R.plurals.dev_export_summary,
+                    count = lastExport.fileCount,
+                    lastExport.fileCount,
+                    formatByteCountCompact(lastExport.byteCount),
+                )
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = TextMuted,
+        )
+
+        lastExport.missingSources.forEach { missing ->
+            Text(
+                stringResource(id = R.string.dev_export_not_included, missing),
+                style = MaterialTheme.typography.bodySmall,
+                color = TextMuted,
+            )
+        }
+    }
 
     Spacer(modifier = Modifier.height(16.dp))
 
@@ -795,15 +990,20 @@ private fun DeveloperToggle(
 @Composable
 private fun DeveloperAction(
     label: String,
+    enabled: Boolean = true,
     onClick: () -> Unit,
 ) {
     Text(
         label,
         style = MaterialTheme.typography.bodyMedium,
-        color = BlueMedium,
+        // a disabled action has to LOOK disabled: an active-looking control
+        // that silently does nothing reads as a broken app, and here the
+        // "nothing" is deliberate (an empty selection, or an export already
+        // running)
+        color = if (enabled) BlueMedium else TextMuted,
         modifier = Modifier
             .padding(vertical = 8.dp)
-            .clickable(onClick = onClick),
+            .clickable(enabled = enabled, onClick = onClick),
     )
 }
 

--- a/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperViewModel.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperViewModel.kt
@@ -68,6 +68,20 @@ class DeveloperViewModel @Inject constructor(
     var lastExport by mutableStateOf<DiagnosticExportSummary?>(null)
         private set
 
+    /**
+     * The verbosity the DEVICE reports it is logging at, or null when there is
+     * no device to ask (signed out, or before one has been created).
+     *
+     * Read back from the device rather than remembered from the last tap. The
+     * level is process-global state behind a glog flag, so a set can be
+     * clamped by the sdk or refused outright (a hosted device) with nothing
+     * thrown here. Showing the value the user asked for would then claim a
+     * capture is running verbose while it is still at 0 -- and the bundle
+     * exported from it would be the empty one this control exists to prevent.
+     */
+    var logVerbosity by mutableStateOf<Long?>(null)
+        private set
+
     var inventory by mutableStateOf<List<LogRow>>(listOf())
         private set
 
@@ -366,6 +380,29 @@ class DeveloperViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Raises or lowers the verbosity of the process that actually writes the
+     * logs worth raising it for.
+     *
+     * Always through the DEVICE, never Sdk.setLogVerbosity: that one reaches
+     * only the calling process, and the transport internals, contract
+     * accounting and window diagnostics are written by the process the device
+     * runs in. Device.SetLogVerbosity is the one that reaches it -- on android
+     * the DeviceLocal in this process, and on the other platform binding the
+     * same call carries the level across to the extension the transport runs
+     * in. Going through the device is what keeps the two honest.
+     *
+     * The level is then READ BACK from the device rather than assumed. The sdk
+     * clamps out-of-range values and a hosted device refuses the call
+     * outright, neither of which throws. Reading back is what makes a set that
+     * did not take visible.
+     */
+    val setLogVerbosity: (Long) -> Unit = { level ->
+        val device = deviceManager.device
+        device?.setLogVerbosity(level)
+        logVerbosity = device?.getLogVerbosity()
+    }
+
     fun toggleLogSelection(name: String) {
         selectedLogNames = if (selectedLogNames.contains(name)) {
             selectedLogNames - name
@@ -376,6 +413,15 @@ class DeveloperViewModel @Inject constructor(
 
     fun refresh() {
         val device = deviceManager.device
+
+        // Polled with the rest of the readout rather than cached from the last
+        // tap: the flag lives in the device's process and the restore a device
+        // runs at construction can move it under us. A stale "Verbose" here is
+        // the one lie this control cannot afford. Read BEFORE the null guard
+        // below, so signing out clears the level to "Unavailable" instead of
+        // leaving the last device's reading on screen.
+        logVerbosity = device?.getLogVerbosity()
+
         if (device == null) {
             exits = listOf()
             reliability = null
@@ -961,6 +1007,98 @@ data class DiagnosticExportSummary(
         )
     }
 }
+
+/**
+ * The three glog levels the sdk defines (`Sdk.LogVerbosityDefault`,
+ * `LogVerbosityVerbose`, `LogVerbosityTrace`), as the java `long` gobind binds
+ * a Go `int` to.
+ *
+ * Named for what each one BUYS, because the whole point of the control is that
+ * the interesting logging is off by default: `connect` gates its contract
+ * accounting, transport internals and window diagnostics behind V(1) and V(2),
+ * so at level 0 a bundle from a live connected session carries rpc chatter and
+ * nothing about contracts or transports at all.
+ */
+const val LOG_VERBOSITY_DEFAULT = 0L
+
+/** V(1): contract accounting and per-packet block decisions. */
+const val LOG_VERBOSITY_VERBOSE = 1L
+
+/** V(2): transport and window internals. */
+const val LOG_VERBOSITY_TRACE = 2L
+
+/** What a tap cycles through, in order. */
+val LOG_VERBOSITY_PRESETS = listOf(
+    LOG_VERBOSITY_DEFAULT,
+    LOG_VERBOSITY_VERBOSE,
+    LOG_VERBOSITY_TRACE,
+)
+
+/**
+ * The level a tap moves to, wrapping back to Default after Trace.
+ *
+ * A level that is not one of the presets lands on the FIRST one, matching the
+ * other stepper rows on this screen. That is reachable in practice: the sdk
+ * reports whatever the `-v` flag says, including a value set past the sdk's
+ * own range by other means, and stepping from an unknown value has to go
+ * somewhere predictable rather than throw out of a click handler.
+ */
+fun nextLogVerbosity(level: Long): Long {
+    val index = LOG_VERBOSITY_PRESETS.indexOf(level)
+    return LOG_VERBOSITY_PRESETS[(index + 1) % LOG_VERBOSITY_PRESETS.size]
+}
+
+/** The three levels this control offers; "no device to ask" is null. */
+enum class LogVerbosityLevel { DEFAULT, VERBOSE, TRACE }
+
+/**
+ * Which level a raw verbosity is displayed as, or null when there is no device
+ * to read one from.
+ *
+ * "No device" and "level 0" are different claims, and reporting the second for
+ * the first is exactly the silent assumption this control exists to avoid.
+ *
+ * Out-of-range values are folded toward the nearest level rather than dropped:
+ * GetLogVerbosity reports the flag itself, so a -v of 5 is a real
+ * possibility, and at 5 every V(2) statement fires -- calling that anything
+ * but Trace would understate what the logs now contain.
+ */
+fun logVerbosityLevel(level: Long?): LogVerbosityLevel? {
+    if (level == null) {
+        return null
+    }
+    return when {
+        level <= LOG_VERBOSITY_DEFAULT -> LogVerbosityLevel.DEFAULT
+        level == LOG_VERBOSITY_VERBOSE -> LogVerbosityLevel.VERBOSE
+        else -> LogVerbosityLevel.TRACE
+    }
+}
+
+/**
+ * The value shown on the control: the number the device reported, then the
+ * name of the level it maps to -- "1 · Verbose".
+ *
+ * Both, because they answer different questions. The name says what the row
+ * means; the number is what the sdk reports, what a support thread compares
+ * against a bundle's manifest, and the only place a level outside the sdk's
+ * range would ever be visible -- a -v of 7 reads "7 · Trace" rather than
+ * being quietly redrawn as 2.
+ */
+fun logVerbosityValueLabel(level: Long, name: String): String = "$level · $name"
+
+/**
+ * True when the level currently in force writes the destination addresses and
+ * ports of real traffic into the logs, which is what the persistent warning on
+ * the screen is for.
+ *
+ * Keyed off the level READ BACK from the device, so the warning is never shown
+ * for a raise that did not actually take, and never hidden for one that did.
+ */
+fun logVerbosityRecordsDestinations(level: Long?): Boolean =
+    when (logVerbosityLevel(level)) {
+        LogVerbosityLevel.VERBOSE, LogVerbosityLevel.TRACE -> true
+        else -> false
+    }
 
 /**
  * A plain-kotlin snapshot of one row of the log inventory.

--- a/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperViewModel.kt
+++ b/app/app/src/main/java/com/bringyour/network/ui/settings/DeveloperViewModel.kt
@@ -4,12 +4,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bringyour.network.APP_LOG_PROCESS_NAME
 import com.bringyour.network.DeviceManager
+import com.bringyour.network.utils.formatByteCountCompact
 import com.bringyour.sdk.Exit
 import com.bringyour.sdk.ReliabilityMetrics
 import com.bringyour.sdk.ReliabilitySettings
+import com.bringyour.sdk.Sdk
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.File
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Backs the Developer section: the reliability toggles, the exit readout, and
@@ -51,7 +60,319 @@ class DeveloperViewModel @Inject constructor(
     var lastAction by mutableStateOf<String?>(null)
         private set
 
+    /**
+     * What the last export produced, as NUMBERS rather than a finished
+     * sentence -- see [DiagnosticExportSummary]. The screen renders it, which
+     * is the only place a `<plurals>` resource can be resolved from.
+     */
+    var lastExport by mutableStateOf<DiagnosticExportSummary?>(null)
+        private set
+
+    var inventory by mutableStateOf<List<LogRow>>(listOf())
+        private set
+
+    var selectedLogNames by mutableStateOf<Set<String>>(setOf())
+        private set
+
+    /**
+     * Sources the exporter will not be able to read, as "<source>: <reason>",
+     * refreshed off the main thread whenever the inventory is.
+     *
+     * The export ui shows any unavailable source with its reason BEFORE the
+     * user commits to an export, not only afterwards in the summary --
+     * learning that the logs were unreachable after zipping them is not
+     * graceful degradation, it is a report of it.
+     */
+    var unavailableSources by mutableStateOf<List<String>>(listOf())
+        private set
+
+    /**
+     * True from the tap that starts an export until its result is on screen.
+     *
+     * Two things need it. (1) Re-entrancy: [diagnosticBundleFileName] has
+     * one-second resolution and only a `-redacted` discriminator, so two
+     * exports of the same mode inside one second name the SAME file and the
+     * second os.Create truncates the zip the first is still streaming into --
+     * the share sheet then hands support a corrupt archive. (2) Feedback: a
+     * full export takes many seconds, and with nothing on screen to show for
+     * the tap, tapping again is the expected user response.
+     */
+    var exporting by mutableStateOf(false)
+        private set
+
+    /** True while the inventory/availability snapshot is being read. */
+    var refreshingDiagnostics by mutableStateOf(false)
+        private set
+
+    /**
+     * A finished bundle waiting to be handed to the share sheet, consumed by
+     * the screen via [consumePendingShare].
+     *
+     * The export deliberately does NOT take a completion lambda: the one the
+     * screen would pass captures the composition's Activity, so a viewmodel
+     * that outlives a rotation would call startActivity on a destroyed one and
+     * would hold it alive for the whole export. Handing back state instead
+     * lets the screen share with whatever context is current.
+     */
+    var pendingShare by mutableStateOf<File?>(null)
+        private set
+
     val connected: Boolean get() = reliability != null
+
+    /** Total on-disk size of everything the exporter can currently see. */
+    val inventoryByteCount: Long get() = inventory.sumOf { it.byteCount }
+
+    /** Total on-disk size of the rows currently checked in the picker. */
+    val selectedByteCount: Long
+        get() = inventory.filter { selectedLogNames.contains(it.name) }.sumOf { it.byteCount }
+
+    /**
+     * Writes a diagnostic bundle into destDir and leaves it in [pendingShare]
+     * for the screen to hand to the share sheet; a failure to write it at all
+     * is reported in [lastExport]. A source that could not be READ is not a
+     * failure: it is recorded inside the bundle, listed in
+     * [unavailableSources] before the export, and repeated in [lastExport]
+     * after it.
+     *
+     * The logcat dump is a blocking external-process spawn, and the bundle
+     * write walks the full on-disk log inventory and zips it (with a per-line
+     * redaction pass when redact is set). Both are blocking i/o; run on the
+     * caller's thread they would block Compose's click dispatch -- the main
+     * thread -- for however long that inventory takes, risking an ANR past
+     * Android's ~5s input-dispatch watchdog on any nontrivial log volume,
+     * exactly the volume a diagnostics export exists to handle. So the work
+     * happens on Dispatchers.IO and the result comes back as state rather than
+     * a return value.
+     *
+     * A tap arriving while [exporting] is already true is dropped: see that
+     * field for why a second concurrent export corrupts the first one's zip.
+     */
+    fun exportDiagnostics(
+        destDir: File,
+        redact: Boolean,
+        selected: List<String>,
+        nowMillis: Long,
+    ) {
+        if (exporting) {
+            return
+        }
+        exporting = true
+        viewModelScope.launch {
+            try {
+                val outcome = withContext(Dispatchers.IO) {
+                    buildDiagnosticBundle(destDir, redact, selected, nowMillis)
+                }
+                lastExport = outcome.summary
+                pendingShare = outcome.file
+            } finally {
+                exporting = false
+            }
+        }
+    }
+
+    /**
+     * The picker's export, and the only caller that may pass a selection.
+     *
+     * Separate from [exportDiagnostics] because an EMPTY selection must never
+     * reach the sdk from this control: empty SelectedNames means "no filter"
+     * there, so "Export selected" with nothing checked would produce a
+     * complete RAW bundle -- every severity, every rotation, plus the logcat
+     * dump and a manifest carrying client_id and instance_id in the clear --
+     * under a label promising a narrow subset. The row is disabled in that
+     * state as well; this is the second guard, so no future caller can
+     * reintroduce the hazard.
+     */
+    fun exportSelectedDiagnostics(destDir: File, nowMillis: Long) {
+        val selected = selectedLogNames.toList()
+        if (!canExportSelection(selected)) {
+            return
+        }
+        exportDiagnostics(destDir, redact = false, selected = selected, nowMillis = nowMillis)
+    }
+
+    /** Clears a bundle once the screen has handed it to the share sheet. */
+    fun consumePendingShare() {
+        pendingShare = null
+    }
+
+    /**
+     * Does the actual (blocking) export work. Called only from
+     * [exportDiagnostics] inside a Dispatchers.IO block -- never touches
+     * mutableStateOf state directly, so it has no thread requirement of its
+     * own beyond "not the main thread".
+     */
+    private fun buildDiagnosticBundle(
+        destDir: File,
+        redact: Boolean,
+        selected: List<String>,
+        nowMillis: Long,
+    ): DiagnosticExportOutcome {
+        val dest = File(destDir, diagnosticBundleFileName(nowMillis, redact))
+        return try {
+            destDir.mkdirs()
+            // A bundle is a handoff to the share sheet, never storage: at up to
+            // 4x16MB of logs each, keeping every past export costs hundreds of
+            // MB until the OS reclaims the cache. This also sweeps up a zip
+            // orphaned by an export whose coroutine was cancelled (navigating
+            // off the screen mid-export) before it could report the file.
+            pruneOldBundles(destDir, dest)
+
+            val options = Sdk.newExportOptions()
+            options.redact = redact
+            options.includeManifest = true
+            options.includePlatformLogs = true
+            selected.forEach { options.selectedNames.add(it) }
+
+            deviceManager.device?.let { options.setManifestJson(it.diagnosticManifestJson()) }
+
+            // A source that cannot be read is RECORDED as missing, not silently
+            // omitted. The sdk cannot do this for us -- LogInventory swallows
+            // directory-read failures and ExportDiagnosticBundle only ever
+            // learns about per-FILE open/stat errors -- so without this an
+            // unreadable log directory yields a bundle with zero log entries,
+            // an empty "NOT INCLUDED" section and "Exported 0 log files", and
+            // the support engineer is told nothing about why.
+            unavailableLogSources().forEach { (source, reason) ->
+                options.missingSourceReason(source, reason)
+            }
+
+            val logcat = readLogcat()
+            val logcatText = logcat.text
+            if (logcatText != null) {
+                options.addPlatformLog(LOGCAT_LOG_NAME, logcatText)
+            } else {
+                // Recorded as a missing SOURCE rather than written as the body
+                // of platform/logcat.txt: a failure stored inside the file it
+                // was supposed to fill never reaches README.txt's NOT INCLUDED
+                // list, the ExportResult, or the summary on screen.
+                options.missingSourceReason(LOGCAT_LOG_NAME, logcat.failureReason)
+            }
+
+            val result = Sdk.exportDiagnosticBundle(dest.absolutePath, options)
+            DiagnosticExportOutcome(
+                dest,
+                DiagnosticExportSummary(
+                    // ExportResult.FileCount is a Go `int`, which gobind binds
+                    // as a java long; a plurals lookup selects on an int
+                    fileCount = result.fileCount.toInt(),
+                    byteCount = result.byteCount,
+                    missingSources = (0 until result.missingSources.len()).map {
+                        result.missingSources.get(it)
+                    },
+                ),
+            )
+        } catch (e: Exception) {
+            DiagnosticExportOutcome(null, DiagnosticExportSummary.failed(e.message))
+        }
+    }
+
+    /** Deletes every previously exported bundle in destDir, keeping [keep]. */
+    private fun pruneOldBundles(destDir: File, keep: File) {
+        destDir.listFiles()?.forEach { file ->
+            if (file.isFile && file != keep && isDiagnosticBundleName(file.name)) {
+                file.delete()
+            }
+        }
+    }
+
+    /**
+     * Every log source the exporter will not be able to read, as
+     * (source, reason) pairs. Empty is the normal case.
+     */
+    private fun unavailableLogSources(): List<Pair<String, String>> {
+        val reason = logSourceUnavailableReason(Sdk.getLogRoot(), APP_LOG_PROCESS_NAME)
+        return if (reason == null) listOf() else listOf(APP_LOG_PROCESS_NAME to reason)
+    }
+
+    /** A logcat dump, or the reason there isn't one. */
+    private data class LogcatDump(val text: String?, val failureReason: String)
+
+    private fun readLogcat(): LogcatDump {
+        var started: Process? = null
+        return try {
+            val process = ProcessBuilder(logcatDumpCommand()).redirectErrorStream(true).start()
+            started = process
+            // Bounded twice: `-t` caps the lines logcat prints, and this caps
+            // what is materialised if the buffer was resized (a developer
+            // debugging the very fault this feature exists for has usually run
+            // `logcat -G 8M`). The dump is held as a kotlin String (2 bytes per
+            // char), copied into a Go string and read again by deflate -- three
+            // live copies, under a Go soft memory limit set to 3/4 of the app
+            // heap.
+            val text = process.inputStream.bufferedReader().use { readAtMost(it, LOGCAT_MAX_CHARS) }
+            // `logcat -d` dumps and exits, but bound the wait anyway: an
+            // unwaited child is left as a zombie, and a logcat that never exits
+            // must not pin this thread forever.
+            if (!process.waitFor(LOGCAT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroy()
+            }
+            LogcatDump(text, "")
+        } catch (e: Exception) {
+            LogcatDump(null, "logcat unavailable: ${e.message}")
+        } finally {
+            // Never leave the child running: stopping at the cap above can
+            // leave logcat with a full pipe and nothing draining it.
+            started?.destroy()
+        }
+    }
+
+    /**
+     * Snapshots the log inventory and the unavailable sources, off the main
+     * thread.
+     *
+     * Sdk.logInventory() is an os.ReadDir of the root plus every process
+     * directory, with an Info() per entry, all across the gomobile bridge. The
+     * rows it returns are Go proxies too, so every source/severity/byteCount
+     * read in the picker would be another JNI hop, repeated per row per
+     * recomposition. Snapshotting into plain kotlin values here removes both.
+     */
+    fun refreshDiagnostics() {
+        if (refreshingDiagnostics) {
+            return
+        }
+        refreshingDiagnostics = true
+        viewModelScope.launch {
+            try {
+                // one hop, both reads: withContext is not inline, so its
+                // result is the way values come back out of it
+                val snapshot = withContext(Dispatchers.IO) {
+                    readLogInventory() to unavailableLogSources()
+                }
+                val rows = snapshot.first
+                inventory = rows
+                unavailableSources = snapshot.second.map { (source, reason) -> "$source: $reason" }
+                // A file can rotate away between opening the picker and
+                // exporting. The sdk filter silently drops a selected name it
+                // no longer finds, so the user would get fewer files than the
+                // picker showed with nothing saying so -- reconcile instead.
+                selectedLogNames = selectedLogNames.intersect(rows.map { it.name }.toSet())
+            } finally {
+                refreshingDiagnostics = false
+            }
+        }
+    }
+
+    private fun readLogInventory(): List<LogRow> {
+        val list = Sdk.logInventory()
+        return (0 until list.len()).map { i ->
+            val info = list.get(i)
+            LogRow(
+                name = info.name,
+                source = info.source,
+                severity = info.severity,
+                byteCount = info.byteCount,
+                modifiedMillis = info.modifiedMillis,
+            )
+        }
+    }
+
+    fun toggleLogSelection(name: String) {
+        selectedLogNames = if (selectedLogNames.contains(name)) {
+            selectedLogNames - name
+        } else {
+            selectedLogNames + name
+        }
+    }
 
     fun refresh() {
         val device = deviceManager.device
@@ -602,5 +923,219 @@ class DeveloperViewModel @Inject constructor(
          * single-destination behaviour, the A/B point.
          */
         val MIN_BLACKHOLE_DESTINATIONS_PRESETS = listOf(0, 1, 2, 3)
+    }
+}
+
+/**
+ * The result of building a bundle off the main thread: the file it landed at
+ * (null if the export failed outright) and the summary for
+ * [DeveloperViewModel.lastExport].
+ */
+private data class DiagnosticExportOutcome(val file: File?, val summary: DiagnosticExportSummary)
+
+/**
+ * What an export produced, carried as numbers.
+ *
+ * The count is deliberately NOT formatted here. Built as
+ * `"Exported ${result.fileCount} log files"` it reads "Exported 1 log files"
+ * for the single-file case that a selective export produces most often. Only a
+ * `<plurals>` resource can pick the right form, only a composable can resolve
+ * one, and a count already baked into a string cannot be pluralised afterwards
+ * -- so the count travels as an Int and `R.plurals.dev_export_summary` selects
+ * on it at the point of display.
+ */
+data class DiagnosticExportSummary(
+    val fileCount: Int,
+    val byteCount: Long,
+    val missingSources: List<String>,
+    /** Non-null when no bundle was written at all; the reason, verbatim. */
+    val failure: String? = null,
+) {
+    companion object {
+        /** An export that produced no bundle. `reason` is an exception message. */
+        fun failed(reason: String?): DiagnosticExportSummary = DiagnosticExportSummary(
+            fileCount = 0,
+            byteCount = 0L,
+            missingSources = listOf(),
+            failure = reason ?: "unknown error",
+        )
+    }
+}
+
+/**
+ * A plain-kotlin snapshot of one row of the log inventory.
+ *
+ * The sdk's LogFileInfo is a gomobile proxy: every field read is a JNI hop
+ * into Go, and Compose reads name/source/severity/byteCount on every
+ * recomposition of the picker. Snapshotting once, off the main thread, keeps
+ * the bridge out of the frame.
+ */
+data class LogRow(
+    val name: String,
+    val source: String,
+    val severity: String,
+    val byteCount: Long,
+    val modifiedMillis: Long,
+)
+
+/** platform/<name> the android logcat dump is written to inside the bundle. */
+const val LOGCAT_LOG_NAME = "logcat.txt"
+
+/**
+ * Line cap on the logcat dump. The stock buffer is 256KB per device, but a
+ * developer debugging the fault this feature exists for has usually run
+ * `logcat -G 8M` -- and the dump is held as a kotlin String, copied into a Go
+ * string and read again by deflate, three live copies at once, under a Go
+ * soft memory limit set to 3/4 of the app heap.
+ */
+const val LOGCAT_MAX_LINES = 20000
+
+/** Hard ceiling on the characters materialised from the dump. */
+private const val LOGCAT_MAX_CHARS = 4 * 1024 * 1024
+
+/** How long to wait for `logcat -d` to exit before killing it. */
+private const val LOGCAT_TIMEOUT_SECONDS = 10L
+
+/** Every diagnostic bundle this app writes starts with this. */
+const val DIAGNOSTIC_BUNDLE_PREFIX = "urnetwork-diagnostics-"
+
+/**
+ * Bundle names sort lexically in the same order they were made, so a support
+ * thread with several attachments reads in order, and carry the mode so a
+ * redacted bundle is never mistaken for a complete one.
+ */
+fun diagnosticBundleFileName(millis: Long, redacted: Boolean): String {
+    val stamp = java.text.SimpleDateFormat("yyyyMMdd-HHmmss", java.util.Locale.US)
+        .apply { timeZone = java.util.TimeZone.getTimeZone("UTC") }
+        .format(java.util.Date(millis))
+    val suffix = if (redacted) "-redacted" else ""
+    return "$DIAGNOSTIC_BUNDLE_PREFIX$stamp$suffix.zip"
+}
+
+/** True for a file this app wrote as a diagnostic bundle. */
+fun isDiagnosticBundleName(name: String): Boolean =
+    name.startsWith(DIAGNOSTIC_BUNDLE_PREFIX) && name.endsWith(".zip")
+
+/**
+ * `logcat -d` dumps and exits. Since android 4.1 an app reads only its OWN
+ * buffer, which is exactly the wanted scope -- no permission is involved and
+ * no other app's entries are reachable. `-t` bounds the dump to the most
+ * recent lines: an unbounded read of a resized buffer is three live copies of
+ * however much the developer asked the device to keep.
+ */
+fun logcatDumpCommand(): List<String> =
+    listOf("logcat", "-d", "-v", "threadtime", "-t", LOGCAT_MAX_LINES.toString())
+
+/**
+ * Reads at most maxChars characters, so a dump larger than expected costs a
+ * bounded allocation instead of the whole buffer.
+ */
+fun readAtMost(reader: java.io.Reader, maxChars: Int): String {
+    val buffer = CharArray(8 * 1024)
+    val out = StringBuilder()
+    while (out.length < maxChars) {
+        val n = reader.read(buffer, 0, minOf(buffer.size, maxChars - out.length))
+        if (n < 0) {
+            break
+        }
+        out.append(buffer, 0, n)
+    }
+    return out.toString()
+}
+
+/**
+ * "Export selected" must never fall back to exporting everything: an empty
+ * SelectedNames means "no filter" to the sdk ("Empty means every file"), so an
+ * unguarded empty selection produces a complete RAW bundle -- every severity,
+ * every rotation, the logcat dump and a manifest carrying client_id and
+ * instance_id in the clear -- from a control whose label promises a narrow
+ * subset.
+ */
+fun canExportSelection(selected: Collection<String>): Boolean = selected.isNotEmpty()
+
+/**
+ * Why the exporter will not be able to read this source's logs, or null when
+ * it can.
+ *
+ * The sdk reports per-file failures but swallows directory-read failures
+ * entirely, so this is the only place an unreadable log directory can be
+ * noticed on android -- and such a source has to be recorded as missing rather
+ * than silently omitted.
+ *
+ * Deliberately path-free: the reason is copied verbatim into the bundle's
+ * README "NOT INCLUDED" list, which the sdk writes without the redaction
+ * transform.
+ */
+fun logSourceUnavailableReason(logRoot: String, source: String): String? {
+    if (logRoot.isEmpty()) {
+        return "no log directory was recorded at startup"
+    }
+    val dir = File(logRoot, source)
+    return when {
+        !dir.exists() -> "no log directory on disk"
+        !dir.isDirectory -> "the log path is not a directory"
+        !dir.canRead() || dir.list() == null -> "the log directory could not be read"
+        else -> null
+    }
+}
+
+/**
+ * What the export would contain, shown before the user commits to it: a
+ * bundle is up to 4x16MB per process, which is not a thing to discover
+ * afterwards.
+ *
+ * Sizes go through the app's own formatByteCountCompact rather than
+ * `byteCount / 1024`: that integer division renders a freshly rotated
+ * 400-byte log as "0 KiB", and in a picker "0" reads as "nothing in this
+ * file" rather than as a rounding.
+ */
+fun inventoryLabel(fileCount: Int, byteCount: Long): String {
+    if (fileCount == 0) {
+        return "No log files on disk"
+    }
+    val files = if (fileCount == 1) "log file" else "log files"
+    return "$fileCount $files on disk · ${formatByteCountCompact(byteCount)}"
+}
+
+/** The same, for the subset currently checked in the picker. */
+fun selectionLabel(fileCount: Int, byteCount: Long): String {
+    if (fileCount == 0) {
+        return "Nothing selected"
+    }
+    val files = if (fileCount == 1) "file" else "files"
+    return "Selected $fileCount $files · ${formatByteCountCompact(byteCount)}"
+}
+
+/**
+ * When a log was last written, UTC, or "" when unknown. The picker's rows name
+ * severity, size AND modified time: which file covers the incident is a
+ * question about time, and the glog file name does not answer it legibly.
+ */
+fun logFileModifiedLabel(modifiedMillis: Long): String {
+    if (modifiedMillis <= 0L) {
+        return ""
+    }
+    val stamp = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US)
+        .apply { timeZone = java.util.TimeZone.getTimeZone("UTC") }
+        .format(java.util.Date(modifiedMillis))
+    return "${stamp}Z"
+}
+
+/** The one-line label for a row in the selective log picker. */
+fun logFileRowLabel(
+    source: String,
+    severity: String,
+    byteCount: Long,
+    modifiedMillis: Long = 0L,
+): String = buildString {
+    append(source)
+    append(" · ")
+    append(severity)
+    append(" · ")
+    append(formatByteCountCompact(byteCount))
+    val modified = logFileModifiedLabel(modifiedMillis)
+    if (modified.isNotEmpty()) {
+        append(" · ")
+        append(modified)
     }
 }

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="dev_busy_probes">Busy probes</string>
     <string name="dev_busy_probes_detail">Liveness pings fired at stalled exits; acquitted ones answered and were kept, the removals the probe prevented</string>
     <string name="dev_busy_probes_value">%1$d sent / %2$d acquitted</string>
+    <string name="dev_choose_logs">Choose logs…</string>
     <string name="dev_cluster_affinity">Group IPs by site</string>
     <string name="dev_cluster_affinity_detail">Keeps a site on one exit when its hostname is not visible</string>
     <string name="dev_comparative_connect">Cut dead connects early</string>
@@ -166,6 +167,14 @@
     <string name="dev_exit_dial_failures">%1$d failed dials</string>
     <string name="dev_exit_flows">%1$d flows</string>
     <string name="dev_exits">Exits</string>
+    <string name="dev_export_all_logs">Export all logs (raw)</string>
+    <string name="dev_export_failed">Export failed: %1$s</string>
+    <string name="dev_export_not_included">Not included: %1$s</string>
+    <string name="dev_export_redacted_logs">Export redacted logs</string>
+    <string name="dev_export_selected">Export selected</string>
+    <string name="dev_export_share">Share diagnostic bundle</string>
+    <string name="dev_export_unavailable">Not available: %1$s</string>
+    <string name="dev_exporting">Exporting…</string>
     <string name="dev_flows_opened">Flows opened</string>
     <string name="dev_flows_opened_detail">Total since reset, so runs of different lengths compare</string>
     <string name="dev_flows_rebound">QUIC flows rebound</string>
@@ -229,6 +238,7 @@
     <string name="dev_scheduler_pauses">Suspends caught</string>
     <string name="dev_scheduler_pauses_detail">Host suspends the detector caught, each one a batch of verdicts held instead of executed on a just-resumed phone</string>
     <string name="dev_section_detection">Detection</string>
+    <string name="dev_section_diagnostics">Diagnostics</string>
     <string name="dev_section_observability">Observability</string>
     <string name="dev_section_placement">Placement</string>
     <string name="dev_section_probing">Probing</string>
@@ -676,6 +686,10 @@
     <plurals name="contract_count">
         <item quantity="one">%1$d contract</item>
         <item quantity="other">%1$d contracts</item>
+    </plurals>
+    <plurals name="dev_export_summary">
+        <item quantity="one">Exported %1$d log file (%2$s)</item>
+        <item quantity="other">Exported %1$d log files (%2$s)</item>
     </plurals>
     <plurals name="host_count">
         <item quantity="one">%1$d host</item>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -194,6 +194,17 @@
     <string name="dev_heartbeat_detail">How often one line summarizing live state is written to the log for later forensics. Off silences it; shorter spots a transition, longer keeps more buffer</string>
     <string name="dev_load_corroboration">Load corroboration</string>
     <string name="dev_load_corroboration_detail">Extra silent destinations required per this many flows before a busy exit can be benched on soft evidence: a 24-flow exit at 8 needs 3 silent sites, not 2. Off keeps the flat minimum</string>
+    <string name="dev_log_verbosity">Log detail</string>
+    <string name="dev_log_verbosity_default">Default</string>
+    <string name="dev_log_verbosity_default_detail">Connection errors and contract pings</string>
+    <string name="dev_log_verbosity_trace">Trace</string>
+    <string name="dev_log_verbosity_trace_detail">Transport and window internals. Very large logs</string>
+    <string name="dev_log_verbosity_unavailable">Unavailable</string>
+    <string name="dev_log_verbosity_unavailable_detail">There is no device to read the log level from yet. Sign in first</string>
+    <string name="dev_log_verbosity_verbose">Verbose</string>
+    <string name="dev_log_verbosity_verbose_detail">Contract accounting and per-packet block decisions. Includes destination IP addresses</string>
+    <string name="dev_log_verbosity_warning">At Verbose and above the logs contain the destination IP addresses and ports of the traffic you send. Use “Export redacted logs” to share them; the raw bundle should not leave this device.</string>
+    <string name="dev_log_verbosity_warning_title">Logs are recording your real traffic</string>
     <string name="dev_max_flows_per_exit">Max connections per exit</string>
     <string name="dev_max_flows_per_exit_detail">Losing an exit kills every connection on it. Lower spreads the damage; a site may then use more than one exit IP</string>
     <string name="dev_measure_none">No provider failures yet. Stall an exit below to cause one.</string>

--- a/app/app/src/test/java/com/bringyour/network/DiagnosticsLogLocationTest.kt
+++ b/app/app/src/test/java/com/bringyour/network/DiagnosticsLogLocationTest.kt
@@ -1,0 +1,90 @@
+package com.bringyour.network
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DiagnosticsLogLocationTest {
+
+    private lateinit var filesDir: File
+
+    @Before
+    fun setUp() {
+        filesDir = Files.createTempDirectory("filesDir").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        filesDir.deleteRecursively()
+    }
+
+    private fun processLogDir(): File = File(logRootDir(filesDir), APP_LOG_PROCESS_NAME)
+
+    @Test
+    fun theLogRootIsASubdirectoryOfFilesDirPerProcess() {
+        assertEquals(File(filesDir, "logs"), logRootDir(filesDir))
+        // the directory name is the label for which process wrote a file, and
+        // it is the same one iOS uses for its app process
+        assertEquals("app", APP_LOG_PROCESS_NAME)
+    }
+
+    @Test
+    fun glogFileNamesAreRecognisedByTheirSeverity() {
+        assertTrue(isGlogFileName("urnetwork.host.user.log.INFO.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.WARNING.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.ERROR.20260101-000000.1234"))
+        assertTrue(isGlogFileName("urnetwork.host.user.log.FATAL.20260101-000000.1234"))
+        assertFalse(isGlogFileName("shared_prefs.xml"))
+        assertFalse(isGlogFileName("urnetwork.log"))
+        assertFalse(isGlogFileName("localstate.db"))
+    }
+
+    @Test
+    fun preUpgradeLogsAreMovedUnderTheProcessRootRatherThanStranded() {
+        // the old build wrote glog files straight into filesDir; nothing prunes
+        // or exports that directory once the root moves, so those files were
+        // both dead storage and unreachable evidence
+        val legacy = File(filesDir, "urnetwork.host.user.log.INFO.20260101-000000.1234")
+        legacy.writeText("pre-upgrade line")
+        val other = File(filesDir, "localstate.db")
+        other.writeText("not a log")
+
+        assertEquals(1, migrateLegacyLogFiles(filesDir, processLogDir()))
+
+        assertFalse("the legacy copy must not be left behind", legacy.exists())
+        val moved = File(processLogDir(), legacy.name)
+        assertTrue("the log must still be exportable", moved.exists())
+        assertEquals("pre-upgrade line", moved.readText())
+        assertTrue("only glog files are touched", other.exists())
+    }
+
+    @Test
+    fun migratingIsIdempotentAndNeverOverwritesALiveLog() {
+        val name = "urnetwork.host.user.log.INFO.20260101-000000.1234"
+        val live = File(processLogDir(), name)
+        assertTrue(processLogDir().mkdirs())
+        live.writeText("the file already under the new root")
+        val legacy = File(filesDir, name)
+        legacy.writeText("the stale duplicate")
+
+        assertEquals(1, migrateLegacyLogFiles(filesDir, processLogDir()))
+
+        assertFalse(legacy.exists())
+        assertEquals("the file already under the new root", live.readText())
+
+        // a second launch has nothing left to do
+        assertEquals(0, migrateLegacyLogFiles(filesDir, processLogDir()))
+    }
+
+    @Test
+    fun anInstallWithNoLegacyLogsIsUntouched() {
+        assertEquals(0, migrateLegacyLogFiles(filesDir, processLogDir()))
+        // no destination directory is created for nothing
+        assertFalse(processLogDir().exists())
+    }
+}

--- a/app/app/src/test/java/com/bringyour/network/ui/settings/DiagnosticExportTest.kt
+++ b/app/app/src/test/java/com/bringyour/network/ui/settings/DiagnosticExportTest.kt
@@ -1,0 +1,201 @@
+package com.bringyour.network.ui.settings
+
+import java.io.File
+import java.io.StringReader
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DiagnosticExportTest {
+
+    @Test
+    fun bundleFileNameIsSortableAndCarriesTheMode() {
+        val raw = diagnosticBundleFileName(millis = 1767225600000L, redacted = false)
+        val redacted = diagnosticBundleFileName(millis = 1767225600000L, redacted = true)
+
+        // pinned exactly, so the UTC formatting this implementation deliberately
+        // does is load-bearing: a bundle stamped in the exporting device's local
+        // zone sorts wrongly against one from another zone, and two bundles from
+        // the same second are indistinguishable in a support thread
+        assertEquals("urnetwork-diagnostics-20260101-000000.zip", raw)
+        assertEquals("urnetwork-diagnostics-20260101-000000-redacted.zip", redacted)
+        assertTrue("raw name should not claim redaction, was $raw", !raw.contains("redacted"))
+        // lexical sort must match chronological sort
+        val earlier = diagnosticBundleFileName(millis = 1767225500000L, redacted = false)
+        assertTrue("$earlier should sort before $raw", earlier < raw)
+    }
+
+    @Test
+    fun exportSelectionIsBlockedWithNothingChecked() {
+        // An empty SelectedNames means "no filter" to the sdk, i.e. every log
+        // file, raw -- the opposite of what "Export selected" promises. This is
+        // the predicate behind both the disabled row and the handler guard.
+        assertFalse(canExportSelection(emptySet()))
+        assertFalse(canExportSelection(emptyList()))
+        assertTrue(canExportSelection(setOf("urnetwork.log.INFO.20260101-000000.1")))
+    }
+
+    @Test
+    fun logcatCommandIsBoundedAndReadsOnlyThisAppsOwnBuffer() {
+        val command = logcatDumpCommand()
+
+        assertEquals("logcat", command[0])
+        // -d dumps and exits; without it logcat streams forever
+        assertTrue("must dump and exit, was $command", command.contains("-d"))
+        // never widen the scope: -b all would pull other apps' buffers into a
+        // bundle the user is about to email to support
+        assertFalse("must not widen the buffer scope, was $command", command.contains("-b"))
+        // bounded: the dump is materialised as a String, copied into a Go
+        // string and read again by deflate
+        val cap = command.indexOf("-t")
+        assertTrue("must bound the dump with -t, was $command", 0 < cap)
+        assertEquals(LOGCAT_MAX_LINES.toString(), command[cap + 1])
+    }
+
+    @Test
+    fun readingTheDumpStopsAtTheCap() {
+        assertEquals("abcde", readAtMost(StringReader("abcdefghij"), 5))
+        assertEquals("abc", readAtMost(StringReader("abc"), 512))
+        assertEquals("", readAtMost(StringReader("abc"), 0))
+    }
+
+    @Test
+    fun inventoryRowLabelNamesTheSourceSeverityAndSizeAndModifiedTime() {
+        val label = logFileRowLabel(
+            source = "extension",
+            severity = "ERROR",
+            byteCount = 2048L,
+            modifiedMillis = 1767225600000L,
+        )
+        assertTrue("should name the source, was $label", label.contains("extension"))
+        assertTrue("should name the severity, was $label", label.contains("ERROR"))
+        assertTrue("should show the size, was $label", label.contains("2.00 KiB"))
+        // the picker's rows carry modified time: which file covers the
+        // incident is a question about time
+        assertTrue("should show when it was written, was $label", label.contains("2026-01-01 00:00Z"))
+    }
+
+    @Test
+    fun rowLabelOmitsAnUnknownModifiedTime() {
+        val label = logFileRowLabel(source = "app", severity = "INFO", byteCount = 2048L, modifiedMillis = 0L)
+        assertEquals("app · INFO · 2.00 KiB", label)
+    }
+
+    @Test
+    fun sizesNeverRenderAFileAsEmptyWhenItIsNot() {
+        // `byteCount / 1024` renders a freshly rotated log as "0 KiB", which in
+        // a picker reads as "nothing in this file" rather than as a rounding.
+        // The app's own formatter is what the rest of the ui already uses.
+        assertEquals("app · INFO · 400 B", logFileRowLabel("app", "INFO", 400L))
+        assertEquals("app · INFO · 1 B", logFileRowLabel("app", "INFO", 1L))
+        assertEquals("app · INFO · 16.0 MiB", logFileRowLabel("app", "INFO", 16L * 1024 * 1024))
+    }
+
+    @Test
+    fun theTotalSizeIsAvailableBeforeExporting() {
+        assertEquals("No log files on disk", inventoryLabel(fileCount = 0, byteCount = 0L))
+        assertEquals("1 log file on disk · 2.00 KiB", inventoryLabel(fileCount = 1, byteCount = 2048L))
+        assertEquals("3 log files on disk · 48.0 MiB", inventoryLabel(fileCount = 3, byteCount = 48L * 1024 * 1024))
+        assertEquals("Nothing selected", selectionLabel(fileCount = 0, byteCount = 0L))
+        assertEquals("Selected 2 files · 4.00 KiB", selectionLabel(fileCount = 2, byteCount = 4096L))
+    }
+
+    @Test
+    fun onlyThisAppsOwnBundlesArePruned() {
+        assertTrue(isDiagnosticBundleName("urnetwork-diagnostics-20260101-000000.zip"))
+        assertTrue(isDiagnosticBundleName("urnetwork-diagnostics-20260101-000000-redacted.zip"))
+        assertTrue(isDiagnosticBundleName(diagnosticBundleFileName(1767225600000L, redacted = true)))
+        // anything else in cacheDir/share belongs to another feature
+        assertFalse(isDiagnosticBundleName("urnetwork-diagnostics-20260101-000000.zip.part"))
+        assertFalse(isDiagnosticBundleName("support-attachment.zip"))
+        assertFalse(isDiagnosticBundleName("urnetwork.log.INFO.20260101-000000.1"))
+    }
+
+    @Test
+    fun anUnreadableLogSourceIsReportedRatherThanSilentlyOmitted() {
+        // the sdk swallows directory-read failures entirely, so this predicate
+        // is the only place android can notice one -- such a source has to be
+        // recorded as missing
+        assertNotNull(logSourceUnavailableReason("", "app"))
+
+        val root = Files.createTempDirectory("logroot").toFile()
+        try {
+            assertNotNull("an absent source directory is missing", logSourceUnavailableReason(root.absolutePath, "app"))
+
+            val notADirectory = File(root, "app")
+            assertTrue(notADirectory.createNewFile())
+            assertNotNull(
+                "a source that is not a directory is missing",
+                logSourceUnavailableReason(root.absolutePath, "app"),
+            )
+            assertTrue(notADirectory.delete())
+
+            assertTrue(File(root, "app").mkdirs())
+            assertNull("a readable source directory is not missing", logSourceUnavailableReason(root.absolutePath, "app"))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun theSummaryCarriesTheCountAsANumberSoItCanBePluralised() {
+        // "Exported 1 log files" -- a count formatted into a fixed English
+        // phrase in the viewmodel, where no <plurals> can be resolved, and a
+        // count already inside a string cannot be pluralised afterwards. So
+        // the summary stays numeric all the way to the screen, which is what
+        // R.plurals.dev_export_summary selects on. A file count of exactly 1
+        // is the common case: it is what a selective export of one log
+        // produces.
+        val one = DiagnosticExportSummary(fileCount = 1, byteCount = 2048L, missingSources = listOf())
+        assertEquals(1, one.fileCount)
+        assertEquals(2048L, one.byteCount)
+        assertNull("a successful export has no failure reason", one.failure)
+        assertTrue(one.missingSources.isEmpty())
+    }
+
+    @Test
+    fun anUnreadableSourceSurvivesIntoTheSummaryRatherThanBeingFlattenedIntoIt() {
+        // each missing source is rendered as its own line by the screen, so it
+        // stays a list here -- the reason has to reach the user, and a
+        // pre-joined string cannot be re-styled or re-localised
+        val summary = DiagnosticExportSummary(
+            fileCount = 3,
+            byteCount = 4096L,
+            missingSources = listOf("app: no log directory on disk", "logcat.txt: logcat unavailable"),
+        )
+        assertEquals(2, summary.missingSources.size)
+        assertEquals("app: no log directory on disk", summary.missingSources[0])
+    }
+
+    @Test
+    fun anExportThatWroteNothingReportsWhyAndClaimsNoFiles() {
+        val failed = DiagnosticExportSummary.failed("permission denied")
+        assertEquals("permission denied", failed.failure)
+        // never "Exported 0 log files" alongside a failure: the count is not a
+        // result when there is no bundle
+        assertEquals(0, failed.fileCount)
+        assertEquals(0L, failed.byteCount)
+        assertTrue(failed.missingSources.isEmpty())
+        // an sdk exception with no message must still say something
+        assertNotNull(DiagnosticExportSummary.failed(null).failure)
+    }
+
+    @Test
+    fun theMissingSourceReasonCarriesNoFilesystemPath() {
+        // the reason is copied verbatim into README.txt, the one bundle entry
+        // the sdk writes WITHOUT the redaction transform
+        val root = Files.createTempDirectory("logroot").toFile()
+        try {
+            val reason = logSourceUnavailableReason(root.absolutePath, "app")
+            assertNotNull(reason)
+            assertFalse("reason must not leak a path, was $reason", reason!!.contains(root.absolutePath))
+            assertFalse("reason must not leak a path, was $reason", reason.contains("/"))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+}

--- a/app/app/src/test/java/com/bringyour/network/ui/settings/LogVerbosityTest.kt
+++ b/app/app/src/test/java/com/bringyour/network/ui/settings/LogVerbosityTest.kt
@@ -1,0 +1,102 @@
+package com.bringyour.network.ui.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The verbosity control's decisions, as pure functions.
+ *
+ * What this pins is the part that can be wrong without anything failing: the
+ * sdk's setter throws nothing, clamps silently and can be refused outright by
+ * the device, so the screen's honesty rests entirely on how a level READ BACK
+ * from the device is interpreted here.
+ */
+class LogVerbosityTest {
+
+    @Test
+    fun theLevelsAreTheThreeTheSdkDefines() {
+        // Sdk.LogVerbosityDefault / Verbose / Trace. Not an arbitrary list:
+        // `connect` gates its diagnostics at V(1) and V(2) only, so anything
+        // above 2 is volume with nothing new to show, and the sdk clamps it
+        assertEquals(listOf(0L, 1L, 2L), LOG_VERBOSITY_PRESETS)
+        assertEquals(0L, LOG_VERBOSITY_DEFAULT)
+        assertEquals(1L, LOG_VERBOSITY_VERBOSE)
+        assertEquals(2L, LOG_VERBOSITY_TRACE)
+    }
+
+    @Test
+    fun tappingCyclesUpAndWrapsBackToDefault() {
+        assertEquals(LOG_VERBOSITY_VERBOSE, nextLogVerbosity(LOG_VERBOSITY_DEFAULT))
+        assertEquals(LOG_VERBOSITY_TRACE, nextLogVerbosity(LOG_VERBOSITY_VERBOSE))
+        // wrapping back to 0 is the only way off Trace, and Trace is the level
+        // that fills the disk -- it must not be a dead end
+        assertEquals(LOG_VERBOSITY_DEFAULT, nextLogVerbosity(LOG_VERBOSITY_TRACE))
+    }
+
+    @Test
+    fun steppingFromAnUnknownLevelLandsOnDefault() {
+        // GetLogVerbosity reports the -v flag itself, not a clamped shadow
+        // copy, so a level outside the sdk's range is reachable when one was
+        // set another way. Stepping from it has to go somewhere predictable
+        // rather than throw out of a click handler.
+        assertEquals(LOG_VERBOSITY_DEFAULT, nextLogVerbosity(7L))
+        assertEquals(LOG_VERBOSITY_DEFAULT, nextLogVerbosity(-3L))
+    }
+
+    @Test
+    fun aLevelWithNoDeviceIsUnknownRatherThanDefault() {
+        // "there is no device to ask" and "the device is at level 0" are
+        // different claims. Reporting the second for the first is exactly the
+        // silent assumption this control exists to avoid: it would show
+        // "Default" for a device that may be running at Trace.
+        assertNull(logVerbosityLevel(null))
+        assertEquals(LogVerbosityLevel.DEFAULT, logVerbosityLevel(0L))
+    }
+
+    @Test
+    fun anOutOfRangeLevelIsNamedForWhatItActuallyLogs() {
+        // at -v=5 every V(2) statement fires, so calling it anything but Trace
+        // would understate what the logs now contain
+        assertEquals(LogVerbosityLevel.TRACE, logVerbosityLevel(5L))
+        // and a negative flag logs nothing V-gated at all
+        assertEquals(LogVerbosityLevel.DEFAULT, logVerbosityLevel(-1L))
+        assertEquals(LogVerbosityLevel.VERBOSE, logVerbosityLevel(1L))
+        assertEquals(LogVerbosityLevel.TRACE, logVerbosityLevel(2L))
+    }
+
+    @Test
+    fun theValueLabelReportsTheLevelTheDeviceGave() {
+        // the name says what the row means; the number is what the sdk reports
+        // and what a support thread compares against a bundle's manifest
+        assertEquals("0 · Default", logVerbosityValueLabel(LOG_VERBOSITY_DEFAULT, "Default"))
+        assertEquals("1 · Verbose", logVerbosityValueLabel(LOG_VERBOSITY_VERBOSE, "Verbose"))
+        assertEquals("2 · Trace", logVerbosityValueLabel(LOG_VERBOSITY_TRACE, "Trace"))
+        // a level set past the sdk's range is reported as the number it
+        // actually is rather than quietly redrawn as 2 -- this row is the only
+        // place the discrepancy could show
+        assertEquals("7 · Trace", logVerbosityValueLabel(7L, "Trace"))
+    }
+
+    @Test
+    fun theDestinationWarningIsShownAtEveryLevelThatRecordsThem() {
+        // the difference between a bundle that is safe to attach to a support
+        // thread and one carrying every site the user visited. V(1) is where
+        // the per-packet block decisions -- with destination addresses and
+        // ports -- start being written.
+        assertFalse(logVerbosityRecordsDestinations(LOG_VERBOSITY_DEFAULT))
+        assertTrue(logVerbosityRecordsDestinations(LOG_VERBOSITY_VERBOSE))
+        assertTrue(logVerbosityRecordsDestinations(LOG_VERBOSITY_TRACE))
+        // an out-of-range level logs strictly more, never less
+        assertTrue(logVerbosityRecordsDestinations(9L))
+    }
+
+    @Test
+    fun noWarningIsClaimedForALevelThatWasNeverReadBack() {
+        // the warning is keyed off the device's answer, so with no device
+        // there is no claim to make in either direction
+        assertFalse(logVerbosityRecordsDestinations(null))
+    }
+}


### PR DESCRIPTION
**Stacked on #475** (→ #474). Needs urnetwork/sdk#150 (merged).

A "Log detail" stepper in the Diagnostics section, above the export actions — because the order is *set the level, reproduce, then export*.

| Level | What it buys |
|---|---|
| 0 Default | connection errors, contract pings |
| 1 Verbose | contract accounting, per-packet routing decisions — **includes destination IPs** |
| 2 Trace | transport and window internals; very large logs |

## Why it exists

`connect` gates roughly 290 of ~700 log statements behind `V(1)`/`V(2)`, and the SDK sets `v=0` at every process start. Measured on a real device: a full connected session at the default level produced **237 lines, entirely rpc chatter**. The same session at Trace produced **42,542 lines** including `[contract]`, `[multi]`, `[t]` and `[rtt]`.

Without this control, an uploaded log from the field cannot contain the thing you would want it for.

## Design points

**Driven through the device**, not the process-local `Sdk` function — the point is reaching the process that writes the connect logs.

**The level is read back from the device**, and "no device" is representable and *distinct from level 0* — it shows Unavailable with an inert row. A row confidently reading "0 · Default" when nothing was actually read is precisely the false reassurance worth avoiding.

**At level ≥ 1 a persistent warning** names the destination addresses and points at the redacted export. That pairing is deliberate: raising verbosity is exactly what makes redaction stop being decorative.

## A caveat worth documenting somewhere user-facing

At Trace the measured burn rate on a real device was **15.6 MiB/min**. Against the 16 MiB file cap and 4 retained files, that is roughly **4 minutes of retained history** — so a bug that takes five minutes to reproduce loses its beginning, with no warning, because the export still succeeds and looks complete. Level 1 gives the contract and routing detail without the per-packet firehose.

## Verification

Not compiled locally (no JDK/SDK/NDK); upstream CI is the first compile and the first run of the new tests. Verified by inspection as with the rest of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)